### PR TITLE
Unify runtime paths under the user data directory

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -9,6 +9,8 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from utils.paths import ensure_dirs, get_index_dir
+
 DEFAULT_EXCLUDED = [
     str(Path.home() / "AppData"),
     "C:/Windows",
@@ -40,11 +42,8 @@ def _default_allow_exts() -> set[str]:
 
 
 def default_index_dir() -> str:
-    if os.name == "nt":
-        base = Path(os.environ.get("APPDATA", Path.home()))
-    else:
-        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return str((base / "KobatoEyes" / "index").resolve())
+    ensure_dirs()
+    return str(get_index_dir())
 
 
 @dataclass

--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -31,6 +31,7 @@ from core.query import translate_query
 from db.connection import get_conn
 from db.repository import search_files
 from utils.image_io import get_thumbnail
+from utils.paths import ensure_dirs, get_db_path
 
 
 class _ThumbnailSignal(QObject):
@@ -168,7 +169,8 @@ class TagsTab(QWidget):
         self._grid_button.toggled.connect(self._on_grid_toggled)
         self._placeholder_button.clicked.connect(self._on_index_now)
 
-        self._conn = get_conn("kobato-eyes.db")
+        ensure_dirs()
+        self._conn = get_conn(get_db_path())
         self.destroyed.connect(lambda: self._conn.close())
 
         self._current_query: Optional[str] = None
@@ -195,7 +197,7 @@ class TagsTab(QWidget):
 
     def _on_index_now(self) -> None:
         db_row = self._conn.execute("PRAGMA database_list").fetchone()
-        db_file = Path(db_row[2]) if db_row and db_row[2] else Path("kobato-eyes.db")
+        db_file = Path(db_row[2]) if db_row and db_row[2] else get_db_path()
         run_index_once(db_file)
         self._status_label.setText("Indexing requested.")
 

--- a/src/utils/image_io.py
+++ b/src/utils/image_io.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover - simplifies headless testing environmen
     QPixmap = None  # type: ignore[assignment]
 
 from utils.fs import to_system_path
+from utils.paths import ensure_dirs, get_cache_dir
 
 DEFAULT_THUMBNAIL_SIZE = (320, 320)
 _THUMB_CACHE_LIMIT = 256
@@ -26,11 +27,8 @@ _THUMB_CACHE_LOCK = Lock()
 
 
 def _thumb_cache_dir() -> Path:
-    if os.name == "nt":
-        base = Path(os.environ.get("APPDATA", Path.home()))
-    else:
-        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
-    cache_dir = base / "KobatoEyes" / "cache" / "thumbs"
+    ensure_dirs()
+    cache_dir = get_cache_dir() / "thumbs"
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
 

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,61 @@
+"""Helpers for resolving application data directories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from platformdirs import PlatformDirs
+
+_APP_NAME = "KobatoEyes"
+_ENV_VAR = "KOE_DATA_DIR"
+
+
+def get_data_dir() -> Path:
+    """Return the directory used to persist application data."""
+
+    override = os.environ.get(_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+
+    dirs = PlatformDirs(appname=_APP_NAME, appauthor=False, roaming=True)
+    return Path(dirs.user_data_dir)
+
+
+def get_db_path() -> Path:
+    """Return the path to the SQLite database file."""
+
+    return get_data_dir() / "kobato-eyes.db"
+
+
+def get_index_dir() -> Path:
+    """Return the directory used to store search indices."""
+
+    return get_data_dir() / "index"
+
+
+def get_cache_dir() -> Path:
+    """Return the directory used to store cache artifacts."""
+
+    return get_data_dir() / "cache"
+
+
+def ensure_dirs() -> None:
+    """Ensure that the application data directories exist."""
+
+    data_dir = get_data_dir()
+    index_dir = get_index_dir()
+    cache_dir = get_cache_dir()
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    index_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "ensure_dirs",
+    "get_cache_dir",
+    "get_data_dir",
+    "get_db_path",
+    "get_index_dir",
+]

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -1,0 +1,35 @@
+"""Tests for the application data path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils import paths
+
+
+@pytest.mark.parametrize("extra", ["", "subdir"])
+def test_get_data_dir_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, extra: str) -> None:
+    override = tmp_path / "data" / extra
+    monkeypatch.setenv("KOE_DATA_DIR", str(override))
+    assert paths.get_data_dir() == override.expanduser()
+
+
+def test_ensure_dirs_creates_structure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    data_dir = tmp_path / "custom_data"
+    monkeypatch.setenv("KOE_DATA_DIR", str(data_dir))
+
+    target_db = paths.get_db_path()
+    cache_dir = paths.get_cache_dir()
+    index_dir = paths.get_index_dir()
+
+    assert not target_db.exists()
+    assert not cache_dir.exists()
+    assert not index_dir.exists()
+
+    paths.ensure_dirs()
+
+    assert target_db.parent.is_dir()
+    assert cache_dir.is_dir()
+    assert index_dir.is_dir()

--- a/tools/migrate_data_paths.py
+++ b/tools/migrate_data_paths.py
@@ -1,0 +1,53 @@
+"""Migrate persisted data into the unified user data directory."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from utils.paths import ensure_dirs, get_data_dir, get_db_path
+
+_LEGACY_BASENAME = "kobato-eyes.db"
+_LEGACY_SUFFIXES = ("", "-wal", "-shm")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def migrate_legacy_data() -> bool:
+    """Move legacy database files into the current data directory."""
+
+    ensure_dirs()
+    target_db = get_db_path()
+    legacy_root = _repo_root()
+    legacy_db = legacy_root / _LEGACY_BASENAME
+
+    if not legacy_db.exists():
+        return False
+
+    if target_db.exists():
+        return False
+
+    target_db.parent.mkdir(parents=True, exist_ok=True)
+
+    for suffix in _LEGACY_SUFFIXES:
+        source = legacy_root / f"{_LEGACY_BASENAME}{suffix}"
+        if source.exists():
+            destination = target_db.with_name(f"{_LEGACY_BASENAME}{suffix}")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(destination))
+
+    return True
+
+
+def main() -> None:
+    moved = migrate_legacy_data()
+    if moved:
+        print(f"Database migrated to {get_db_path()}")
+    else:
+        print(f"No migration required. Data directory is {get_data_dir()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utils.paths` helpers to resolve the user data directory with optional overrides
- update pipeline, UI, and image cache code to create and use the unified data, index, and cache locations
- add a migration script for legacy databases and tests covering the new path helpers

## Testing
- `KOE_HEADLESS=1 PYTHONPATH=src pytest -m "not gui" tests/utils tests/db tests/core`
- `KOE_DATA_DIR=$(pwd)/.tmp_data PYTHONPATH=src python tools/migrate_data_paths.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3297b5c2083239ae5612015b17b6c