### PR TITLE
Implement batched filesystem watcher indexing

### DIFF
--- a/src/ui/settings_tab.py
+++ b/src/ui/settings_tab.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QDoubleSpinBox,
     QFormLayout,
@@ -51,6 +52,9 @@ class SettingsTab(QWidget):
         self._model_combo = QComboBox(self)
         self._model_combo.addItems(["ViT-L-14", "ViT-H-14", "RN50"])
 
+        self._auto_index_check = QCheckBox("Auto index changes", self)
+        self._auto_index_check.setChecked(True)
+
         apply_button = QPushButton("Apply", self)
         apply_button.clicked.connect(self._emit_settings)
 
@@ -61,6 +65,7 @@ class SettingsTab(QWidget):
         form.addRow("Cosine threshold", self._cosine_spin)
         form.addRow("SSIM threshold", self._ssim_spin)
         form.addRow("Model", self._model_combo)
+        form.addRow(self._auto_index_check)
 
         layout = QVBoxLayout(self)
         layout.addLayout(form)
@@ -75,6 +80,7 @@ class SettingsTab(QWidget):
         self._hamming_spin.setValue(settings.hamming_threshold)
         self._cosine_spin.setValue(settings.cosine_threshold)
         self._ssim_spin.setValue(settings.ssim_threshold)
+        self._auto_index_check.setChecked(bool(settings.auto_index))
         index = self._model_combo.findText(settings.model_name)
         if index >= 0:
             self._model_combo.setCurrentIndex(index)
@@ -87,6 +93,7 @@ class SettingsTab(QWidget):
             cosine_threshold=float(self._cosine_spin.value()),
             ssim_threshold=float(self._ssim_spin.value()),
             embed_model=EmbedModel(name=self._model_combo.currentText()),
+            auto_index=self._auto_index_check.isChecked(),
         )
         save_settings(settings)
         self.settings_applied.emit(settings)

--- a/tests/core/test_settings_defaults.py
+++ b/tests/core/test_settings_defaults.py
@@ -12,6 +12,7 @@ from core.settings import PipelineSettings
 def test_defaults_are_applied() -> None:
     settings = PipelineSettings()
 
+    assert settings.auto_index is True
     assert settings.hamming_threshold == 10
     assert settings.cosine_threshold == pytest.approx(0.90)
     assert settings.ssim_threshold == pytest.approx(0.92)

--- a/tests/core/test_watcher_batch.py
+++ b/tests/core/test_watcher_batch.py
@@ -1,0 +1,91 @@
+"""Tests for batching behaviour of the directory watcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable, List, Tuple
+
+import pytest
+
+from core.watcher import DirectoryWatcher
+
+
+class _DummyObserver:
+    """Minimal watchdog observer stub used for unit tests."""
+
+    def __init__(self) -> None:
+        self.handler = None
+        self.args = None
+        self.started = False
+
+    def schedule(self, handler, path: str, recursive: bool) -> None:  # noqa: D401
+        self.handler = handler
+        self.args = (path, recursive)
+
+    def start(self) -> None:  # noqa: D401
+        self.started = True
+
+    def stop(self) -> None:  # noqa: D401
+        self.started = False
+
+    def join(self, timeout: float | None = None) -> None:  # noqa: D401
+        return None
+
+
+@pytest.fixture()
+def observer_factory() -> Tuple[Callable[[], _DummyObserver], List[_DummyObserver]]:
+    created: List[_DummyObserver] = []
+
+    def factory() -> _DummyObserver:
+        observer = _DummyObserver()
+        created.append(observer)
+        return observer
+
+    return factory, created
+
+
+def test_batching_and_deduplication(
+    tmp_path: Path, observer_factory: Tuple[Callable[[], _DummyObserver], List[_DummyObserver]]
+) -> None:
+    factory, created = observer_factory
+    calls: list[list[Path]] = []
+
+    watcher = DirectoryWatcher(
+        roots=[tmp_path],
+        callback=lambda paths: calls.append(paths),
+        extensions={".png"},
+        use_qtimer=False,
+        observer_factory=factory,
+    )
+    watcher.start()
+
+    assert created
+    handler = created[0].handler
+    assert handler is not None
+
+    first_image = tmp_path / "first.png"
+    first_image.write_bytes(b"data")
+
+    event = SimpleNamespace(src_path=str(first_image), is_directory=False)
+    handler.on_created(event)
+    handler.on_modified(event)
+
+    assert not calls
+
+    watcher.flush_pending()
+    assert len(calls) == 1
+    assert calls[0] == [first_image.resolve()]
+
+    calls.clear()
+
+    moved_target = tmp_path / "second.png"
+    moved_target.write_bytes(b"more")
+    moved_event = SimpleNamespace(src_path=str(first_image), dest_path=str(moved_target), is_directory=False)
+    handler.on_moved(moved_event)
+
+    watcher.flush_pending()
+    assert len(calls) == 1
+    assert calls[0] == [moved_target.resolve()]
+
+    watcher.stop()


### PR DESCRIPTION
## Summary
- batch filesystem watcher events per root and dispatch them through a callback
- add partial indexing support in the processing pipeline with auto-index toggles in settings and UI
- cover watcher batching behaviour with new unit tests and update settings defaults

## Testing
- KOE_HEADLESS=1 PYTHONPATH=src pytest -m "not gui" tests/core

------
https://chatgpt.com/codex/tasks/task_e_68d3328d7a748323ae836ba2733f429b