### PR TITLE
Add WD14 tagger configuration support

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -61,6 +61,9 @@ _DEFAULT_PRETRAINED_TAGS = {
 }
 
 
+_VALID_EMBED_DEVICES = {"auto", "cuda", "cpu"}
+
+
 def _default_pretrained(model_name: str) -> str:
     return _DEFAULT_PRETRAINED_TAGS.get(model_name, "openai")
 
@@ -69,7 +72,7 @@ def _default_pretrained(model_name: str) -> str:
 class EmbedModel:
     name: str = "ViT-L-14"
     pretrained: str = "openai"
-    device: str = "cuda"
+    device: str = "auto"
     dim: int = 768
 
     def __post_init__(self) -> None:
@@ -78,6 +81,11 @@ class EmbedModel:
         self.pretrained = self.pretrained.strip()
         if not self.pretrained:
             self.pretrained = _default_pretrained(self.name)
+        device_value = (self.device or "auto") if isinstance(self.device, str) else str(self.device)
+        device_normalised = device_value.strip().lower()
+        if device_normalised not in _VALID_EMBED_DEVICES:
+            device_normalised = "auto"
+        self.device = device_normalised
 
 
 @dataclass

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -50,6 +50,7 @@ def default_index_dir() -> str:
 class TaggerSettings:
     name: str = "dummy"
     model_path: str | None = None
+    tags_csv: str | None = None
     thresholds: dict[str, float] = field(default_factory=lambda: DEFAULT_TAG_THRESHOLDS.copy())
 
 
@@ -157,9 +158,12 @@ class PipelineSettings:
                 tagger_thresholds[str(key)] = float(value)
             except (TypeError, ValueError):
                 continue
+        tagger_model = _coerce_optional_path(tagger_conf.get("model_path", defaults.tagger.model_path))
+        tagger_csv = _coerce_optional_path(tagger_conf.get("tags_csv", defaults.tagger.tags_csv))
         tagger = TaggerSettings(
             name=str(tagger_conf.get("name", defaults.tagger.name)),
-            model_path=tagger_conf.get("model_path", defaults.tagger.model_path),
+            model_path=tagger_model,
+            tags_csv=tagger_csv,
             thresholds=tagger_thresholds,
         )
 
@@ -218,6 +222,7 @@ class PipelineSettings:
             "tagger": {
                 "name": self.tagger.name,
                 "model_path": self.tagger.model_path,
+                "tags_csv": self.tagger.tags_csv,
                 "thresholds": self.tagger.thresholds,
             },
             "embed_model": {
@@ -288,6 +293,12 @@ def _coerce_str(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+def _coerce_optional_path(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
 
 
 __all__ = [

--- a/src/ui/settings_tab.py
+++ b/src/ui/settings_tab.py
@@ -55,6 +55,11 @@ class SettingsTab(QWidget):
         self._model_combo = QComboBox(self)
         self._model_combo.addItems(["ViT-L-14", "ViT-H-14", "RN50"])
 
+        self._device_combo = QComboBox(self)
+        self._device_combo.addItem("Auto", "auto")
+        self._device_combo.addItem("CUDA", "cuda")
+        self._device_combo.addItem("CPU", "cpu")
+
         self._pretrained_edit = QLineEdit(self)
         self._pretrained_edit.setPlaceholderText("e.g. openai")
 
@@ -85,6 +90,7 @@ class SettingsTab(QWidget):
         form.addRow("Cosine threshold", self._cosine_spin)
         form.addRow("SSIM threshold", self._ssim_spin)
         form.addRow("Model", self._model_combo)
+        form.addRow("Device", self._device_combo)
         form.addRow("Pretrained tag", self._pretrained_edit)
         form.addRow("Tagger", self._tagger_combo)
         form.addRow("Model path", tagger_model_row)
@@ -110,6 +116,11 @@ class SettingsTab(QWidget):
         if index >= 0:
             self._model_combo.setCurrentIndex(index)
         self._pretrained_edit.setText(settings.embed_model.pretrained)
+        device_index = self._device_combo.findData(settings.embed_model.device)
+        if device_index >= 0:
+            self._device_combo.setCurrentIndex(device_index)
+        else:
+            self._device_combo.setCurrentIndex(0)
         tagger_index = self._tagger_combo.findText(settings.tagger.name)
         if tagger_index >= 0:
             self._tagger_combo.setCurrentIndex(tagger_index)
@@ -140,6 +151,7 @@ class SettingsTab(QWidget):
             embed_model=EmbedModel(
                 name=self._model_combo.currentText(),
                 pretrained=self._pretrained_edit.text().strip(),
+                device=str(self._device_combo.currentData()),
             ),
             auto_index=self._auto_index_check.isChecked(),
             tagger=tagger_settings,

--- a/tests/sig/test_openclip_pretrained_fallback.py
+++ b/tests/sig/test_openclip_pretrained_fallback.py
@@ -29,9 +29,12 @@ def _patch_openclip(
     def fake_list_pretrained() -> list[tuple[str, str]]:
         return [("ViT-L-14", tag) for tag in available]
 
-    def fake_create_model_and_transforms(model_name: str, pretrained: str):
+    def fake_create_model_and_transforms(
+        model_name: str, *, pretrained: str, device: object | None = None
+    ):
         recorded["model_name"] = model_name
         recorded["pretrained"] = pretrained
+        recorded["device"] = device
         return _DummyModel(), lambda image: image
 
     monkeypatch.setattr("sig.embedder.open_clip.list_pretrained", fake_list_pretrained)

--- a/tests/sig/test_openclip_res_tuple.py
+++ b/tests/sig/test_openclip_res_tuple.py
@@ -1,0 +1,88 @@
+"""Tests for OpenClipEmbedder handling of varying return signatures."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from sig.embedder import OpenClipEmbedder
+
+
+@pytest.fixture(autouse=True)
+def _stub_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a predictable list_pretrained implementation for tests."""
+
+    def _list_pretrained() -> list[tuple[str, str]]:
+        return [("ViT-L-14", "openai")]
+
+    monkeypatch.setattr("sig.embedder.open_clip.list_pretrained", _list_pretrained)
+
+
+def _build_model(output_dim: int = 512) -> MagicMock:
+    model = MagicMock()
+    model.visual = SimpleNamespace(output_dim=output_dim)
+    model.to.return_value = model
+    model.eval.return_value = model
+    model.half.return_value = model
+    return model
+
+
+def test_openclip_supports_two_tuple_return(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = _build_model(320)
+    preprocess = object()
+    create_mock = MagicMock(return_value=(model, preprocess))
+    monkeypatch.setattr(
+        "sig.embedder.open_clip.create_model_and_transforms", create_mock
+    )
+
+    embedder = OpenClipEmbedder("ViT-L-14", "openai", device="cpu")
+
+    assert embedder.embedding_dim == 320
+    assert embedder._preprocess is preprocess  # type: ignore[attr-defined]
+    assert create_mock.call_args.kwargs["pretrained"] == "openai"
+    assert create_mock.call_args.kwargs["device"].type == "cpu"
+
+
+def test_openclip_supports_three_tuple_return(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = _build_model(640)
+    preprocess_train = object()
+    preprocess_val = object()
+    create_mock = MagicMock(return_value=(model, preprocess_train, preprocess_val))
+    monkeypatch.setattr(
+        "sig.embedder.open_clip.create_model_and_transforms", create_mock
+    )
+
+    embedder = OpenClipEmbedder("ViT-L-14", "openai", device="cpu")
+
+    assert embedder.embedding_dim == 640
+    assert embedder._preprocess is preprocess_val  # type: ignore[attr-defined]
+
+
+def test_openclip_falls_back_when_pretrained_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    model = _build_model(128)
+    preprocess = object()
+    create_mock = MagicMock(return_value=(model, preprocess))
+    monkeypatch.setattr(
+        "sig.embedder.open_clip.create_model_and_transforms", create_mock
+    )
+
+    def _list_pretrained() -> list[tuple[str, str]]:
+        return [("ViT-L-14", "laion2b_s32b_b82k"), ("ViT-L-14", "openai")]
+
+    monkeypatch.setattr("sig.embedder.open_clip.list_pretrained", _list_pretrained)
+
+    with caplog.at_level(logging.INFO):
+        embedder = OpenClipEmbedder("ViT-L-14", "nonexistent", device="cpu")
+
+    assert embedder.embedding_dim == 128
+    assert create_mock.call_count == 1
+    assert create_mock.call_args.kwargs["pretrained"] == "laion2b_s32b_b82k"
+    warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("falling back" in message for message in warning_messages)
+    info_messages = [record.message for record in caplog.records if record.levelno == logging.INFO]
+    assert any("laion2b_s32b_b82k" in message for message in info_messages)

--- a/tests/tagger/test_wd14_load.py
+++ b/tests/tagger/test_wd14_load.py
@@ -1,0 +1,76 @@
+"""Tests for WD14 ONNX tagger configuration handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tagger import wd14_onnx
+from tagger.base import TagCategory
+
+
+@pytest.fixture(autouse=True)
+def _mock_ort(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a lightweight fake onnxruntime implementation for tests."""
+
+    class _DummySession:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - signature compatibility
+            self._inputs = [SimpleNamespace(name="input_0")]
+            self._outputs = [SimpleNamespace(name="output_0")]
+
+        def get_inputs(self) -> list[SimpleNamespace]:
+            return self._inputs
+
+        def get_outputs(self) -> list[SimpleNamespace]:
+            return self._outputs
+
+    class _DummyOrt:
+        class SessionOptions:  # noqa: D401 - simple placeholder
+            def __init__(self) -> None:
+                pass
+
+        InferenceSession = _DummySession
+
+    monkeypatch.setattr(wd14_onnx, "ort", _DummyOrt)
+    monkeypatch.setattr(wd14_onnx, "_IMPORT_ERROR", None)
+
+
+@pytest.fixture
+def _mock_labels(monkeypatch: pytest.MonkeyPatch):
+    """Track the label CSV path WD14Tagger attempts to load."""
+    captured: list[Path] = []
+
+    def _fake_loader(path: str | Path) -> list[wd14_onnx._Label]:  # type: ignore[name-defined]
+        captured.append(Path(path))
+        return [wd14_onnx._Label(name="tag", category=TagCategory.GENERAL)]
+
+    monkeypatch.setattr(wd14_onnx.WD14Tagger, "_load_labels", staticmethod(_fake_loader))
+    return captured
+
+
+def test_wd14_tagger_auto_discovers_csv(tmp_path: Path, _mock_labels: list[Path]) -> None:
+    """WD14Tagger should locate selected_tags.csv next to the model."""
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"dummy")
+    csv_path = tmp_path / "selected_tags.csv"
+    csv_path.write_text("tag,0\n", encoding="utf-8")
+
+    tagger = wd14_onnx.WD14Tagger(model_path)
+
+    assert _mock_labels[0] == csv_path
+    assert tagger._labels_path == csv_path  # type: ignore[attr-defined]
+
+
+def test_wd14_tagger_respects_explicit_csv(tmp_path: Path, _mock_labels: list[Path]) -> None:
+    """WD14Tagger should honour an explicit tags_csv path."""
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"dummy")
+    csv_path = tmp_path / "custom.csv"
+    csv_path.write_text("tag,0\n", encoding="utf-8")
+
+    tagger = wd14_onnx.WD14Tagger(model_path, tags_csv=csv_path)
+
+    assert _mock_labels[0] == csv_path
+    assert tagger._labels_path == csv_path  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add UI controls for selecting the tagger backend and choosing a WD14 model path
- persist optional WD14 tags_csv information in pipeline settings and auto-discover selected_tags.csv next to the model
- improve WD14 tagger initialisation to log concise messages, surface errors to the UI, and add tests covering CSV discovery

## Testing
- KOE_HEADLESS=1 PYTHONPATH=src pytest -m "not gui" tests/tagger

------
https://chatgpt.com/codex/tasks/task_e_68d346bd0bbc8323a7ca36939face2e9