### PR TITLE
Unify AppData directory naming and migrate legacy data

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -20,7 +20,7 @@ from db.connection import bootstrap_if_needed
 from ui.dup_tab import DupTab
 from ui.settings_tab import SettingsTab
 from ui.tags_tab import TagsTab
-from utils.paths import ensure_dirs, get_db_path
+from utils.paths import ensure_dirs, get_db_path, migrate_data_dir_if_needed
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ class MainWindow(QMainWindow):
 
     def __init__(self) -> None:
         super().__init__()
+        migrate_data_dir_if_needed()
         ensure_dirs()
         db_path = get_db_path()
         logger.info("DB at %s", db_path)

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import shutil
 from pathlib import Path
 
 from platformdirs import PlatformDirs
 
-_APP_NAME = "KobatoEyes"
+logger = logging.getLogger(__name__)
+
+_APP_NAME = "kobato-eyes"
+_LEGACY_APP_NAME = "KobatoEyes"
 _ENV_VAR = "KOE_DATA_DIR"
+
+
+def _platform_data_dir(appname: str) -> Path:
+    """Return the data directory resolved by :mod:`platformdirs`."""
+
+    dirs = PlatformDirs(appname=appname, appauthor=False, roaming=True)
+    return Path(dirs.user_data_dir)
 
 
 def get_data_dir() -> Path:
@@ -18,8 +30,7 @@ def get_data_dir() -> Path:
     if override:
         return Path(override).expanduser()
 
-    dirs = PlatformDirs(appname=_APP_NAME, appauthor=False, roaming=True)
-    return Path(dirs.user_data_dir)
+    return _platform_data_dir(_APP_NAME)
 
 
 def get_db_path() -> Path:
@@ -52,10 +63,80 @@ def ensure_dirs() -> None:
     cache_dir.mkdir(parents=True, exist_ok=True)
 
 
+def migrate_data_dir_if_needed() -> bool:
+    """Move data from the legacy directory name to the current one.
+
+    Returns ``True`` when at least one entry was migrated.
+    """
+
+    override = os.environ.get(_ENV_VAR)
+    if override:
+        logger.info(
+            "Environment variable %s is set to %s; skipping data directory migration.",
+            _ENV_VAR,
+            override,
+        )
+        return False
+
+    target_dir = _platform_data_dir(_APP_NAME)
+    legacy_dir = _platform_data_dir(_LEGACY_APP_NAME)
+
+    if os.path.normcase(str(legacy_dir)) == os.path.normcase(str(target_dir)):
+        logger.info("Legacy data directory already matches target path %s.", target_dir)
+        return False
+
+    legacy_path = Path(legacy_dir)
+    target_path = Path(target_dir)
+
+    if not legacy_path.exists():
+        logger.info("No legacy data directory found at %s; skipping migration.", legacy_path)
+        return False
+
+    if not legacy_path.is_dir():
+        logger.info(
+            "Legacy data path %s is not a directory; skipping migration.", legacy_path
+        )
+        return False
+
+    target_path.mkdir(parents=True, exist_ok=True)
+
+    moved_any = False
+    skipped: list[str] = []
+
+    for entry in legacy_path.iterdir():
+        destination = target_path / entry.name
+        if destination.exists():
+            skipped.append(entry.name)
+            continue
+        shutil.move(str(entry), str(destination))
+        moved_any = True
+
+    if moved_any:
+        logger.info("Migrated data directory from %s to %s.", legacy_path, target_path)
+    else:
+        logger.info("Legacy directory %s had nothing to migrate.", legacy_path)
+
+    if skipped:
+        logger.info(
+            "Skipped migrating entries already present in %s: %s",
+            target_path,
+            ", ".join(sorted(skipped)),
+        )
+
+    try:
+        legacy_path.rmdir()
+    except OSError:
+        # Directory still contains skipped items; leave it for manual review.
+        pass
+
+    return moved_any
+
+
 __all__ = [
     "ensure_dirs",
     "get_cache_dir",
     "get_data_dir",
     "get_db_path",
     "get_index_dir",
+    "migrate_data_dir_if_needed",
 ]

--- a/tests/utils/test_paths_migration.py
+++ b/tests/utils/test_paths_migration.py
@@ -1,0 +1,69 @@
+"""Tests for migrating legacy data directories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils import paths
+
+
+def test_migrate_data_dir_moves_legacy_contents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure legacy data directories are migrated without overwriting files."""
+
+    monkeypatch.delenv("KOE_DATA_DIR", raising=False)
+
+    legacy_dir = tmp_path / "KobatoEyes"
+    target_dir = tmp_path / "kobato-eyes"
+    legacy_dir.mkdir()
+    target_dir.mkdir()
+
+    class DummyPlatformDirs:
+        def __init__(
+            self, appname: str, appauthor: bool = False, roaming: bool = True
+        ) -> None:
+            mapping = {
+                "kobato-eyes": target_dir,
+                "KobatoEyes": legacy_dir,
+            }
+            self.user_data_dir = str(mapping[appname])
+
+    monkeypatch.setattr(paths, "PlatformDirs", DummyPlatformDirs)
+
+    (legacy_dir / "kobato-eyes.db").write_text("legacy-db")
+    (legacy_dir / "kobato-eyes.db-wal").write_text("legacy-wal")
+    (legacy_dir / "kobato-eyes.db-shm").write_text("legacy-shm")
+    (legacy_dir / "config.yaml").write_text("legacy-config")
+
+    index_dir = legacy_dir / "index"
+    index_dir.mkdir()
+    (index_dir / "entries").write_text("index-data")
+
+    cache_dir = legacy_dir / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "item.bin").write_text("cache-data")
+
+    existing_config = target_dir / "config.yaml"
+    existing_config.write_text("current-config")
+
+    moved = paths.migrate_data_dir_if_needed()
+
+    assert moved is True
+    assert (target_dir / "kobato-eyes.db").read_text() == "legacy-db"
+    assert (target_dir / "kobato-eyes.db-wal").read_text() == "legacy-wal"
+    assert (target_dir / "kobato-eyes.db-shm").read_text() == "legacy-shm"
+    assert (target_dir / "index" / "entries").read_text() == "index-data"
+    assert (target_dir / "cache" / "item.bin").read_text() == "cache-data"
+    assert existing_config.read_text() == "current-config"
+    assert (legacy_dir / "config.yaml").read_text() == "legacy-config"
+    assert not (legacy_dir / "index").exists()
+    assert not (legacy_dir / "cache").exists()
+
+    moved_again = paths.migrate_data_dir_if_needed()
+
+    assert moved_again is False
+    assert (target_dir / "kobato-eyes.db").read_text() == "legacy-db"
+    assert (legacy_dir / "config.yaml").read_text() == "legacy-config"

--- a/tools/migrate_data_paths.py
+++ b/tools/migrate_data_paths.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from utils.paths import ensure_dirs, get_data_dir, get_db_path
+from utils.paths import (
+    ensure_dirs,
+    get_data_dir,
+    get_db_path,
+    migrate_data_dir_if_needed,
+)
 
 _LEGACY_BASENAME = "kobato-eyes.db"
 _LEGACY_SUFFIXES = ("", "-wal", "-shm")
@@ -15,8 +20,8 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def migrate_legacy_data() -> bool:
-    """Move legacy database files into the current data directory."""
+def migrate_legacy_repo_database() -> bool:
+    """Move legacy database files from the repository root into the data directory."""
 
     ensure_dirs()
     target_db = get_db_path()
@@ -41,10 +46,18 @@ def migrate_legacy_data() -> bool:
     return True
 
 
+def migrate_legacy_data() -> bool:
+    """Perform all supported data migrations."""
+
+    moved_repo_db = migrate_legacy_repo_database()
+    moved_app_dir = migrate_data_dir_if_needed()
+    return moved_repo_db or moved_app_dir
+
+
 def main() -> None:
     moved = migrate_legacy_data()
     if moved:
-        print(f"Database migrated to {get_db_path()}")
+        print(f"Migration completed. Data directory is {get_data_dir()}")
     else:
         print(f"No migration required. Data directory is {get_data_dir()}")
 


### PR DESCRIPTION
## Summary
- fix application data path resolution to always use the "kobato-eyes" directory and migrate from the legacy "KobatoEyes" location without overwriting existing files
- trigger the migration during application startup and refresh the manual migration script to cover both legacy directories and repository-root database files
- add regression coverage for the directory migration to ensure idempotent behavior

## Testing
- KOE_HEADLESS=1 PYTHONPATH=src pytest -m "not gui" tests/utils

------
https://chatgpt.com/codex/tasks/task_e_68d352bd75648323a94ae8ca18a0fceb