### PR TITLE
Log active tagger usage and retained tags

### DIFF
--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -515,10 +515,12 @@ class TagsTab(QWidget):
         self._indexing_active = False
         elapsed = float(stats.get("elapsed_sec", 0.0) or 0.0)
         self._status_label.setText(f"Indexing complete in {elapsed:.2f}s.")
+        tagger_name = str(stats.get("tagger_name") or "unknown")
         self._show_toast(
             f"Indexed: {int(stats.get('scanned', 0))} files / "
             f"Tagged: {int(stats.get('tagged', 0))} / "
-            f"Embedded: {int(stats.get('embedded', 0))}"
+            f"Embedded: {int(stats.get('embedded', 0))} "
+            f"(tagger: {tagger_name})"
         )
         self._update_control_states()
         QTimer.singleShot(0, self._on_search_clicked)

--- a/tests/core/test_pipeline_logging.py
+++ b/tests/core/test_pipeline_logging.py
@@ -1,0 +1,21 @@
+"""Tests for pipeline logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from core.pipeline import _build_max_tags_map, _build_threshold_map, _resolve_tagger
+from core.settings import PipelineSettings, TaggerSettings
+
+
+def test_resolve_tagger_logs_active_choice(caplog) -> None:
+    settings = PipelineSettings(tagger=TaggerSettings(name="dummy"))
+    caplog.set_level(logging.INFO, logger="core.pipeline")
+    thresholds = _build_threshold_map(settings.tagger.thresholds)
+    max_tags = _build_max_tags_map(getattr(settings.tagger, "max_tags", None))
+
+    _resolve_tagger(settings, None, thresholds=thresholds, max_tags=max_tags)
+
+    assert any(
+        record.message.startswith("Tagger in use: dummy") for record in caplog.records
+    )

--- a/tests/ui/test_index_now_headless.py
+++ b/tests/ui/test_index_now_headless.py
@@ -52,6 +52,7 @@ def test_index_now_async_flow(tags_tab: TagsTab, qapp: QApplication) -> None:
             "new_or_changed": 2,
             "signatures": 2,
             "hnsw_added": 1,
+            "tagger_name": "dummy",
         }
 
     search_spy = mock.MagicMock()
@@ -80,6 +81,6 @@ def test_index_now_async_flow(tags_tab: TagsTab, qapp: QApplication) -> None:
     assert tags_tab._toast_label.isVisible()  # type: ignore[attr-defined]
     assert (
         tags_tab._toast_label.text()  # type: ignore[attr-defined]
-        == "Indexed: 3 files / Tagged: 2 / Embedded: 1"
+        == "Indexed: 3 files / Tagged: 2 / Embedded: 1 (tagger: dummy)"
     )
     assert tags_tab._placeholder_button.isEnabled()  # type: ignore[attr-defined]

--- a/tests/ui/test_tags_tab_smoke.py
+++ b/tests/ui/test_tags_tab_smoke.py
@@ -61,6 +61,7 @@ def test_index_now_triggers_pipeline(tags_tab: TagsTab) -> None:
             "new_or_changed": 1,
             "signatures": 1,
             "hnsw_added": 1,
+            "tagger_name": "dummy",
         }
 
     with patch("ui.tags_tab.run_index_once", side_effect=_fake_run_index_once) as mocked:


### PR DESCRIPTION
## Summary
- log the resolved tagger details when indexing and track retained tag counts per image
- expose the tagger name through run_index_once so the UI toast shows which model handled tagging
- add a regression test that captures the new logging output and update UI tests for the extended toast text

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d35623fca88323a334b1a54e93f737