### PR TITLE
Fix tag query alias handling

### DIFF
--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -388,7 +388,7 @@ class TagsTab(QWidget):
         query = self._query_input.text().strip()
         self._set_busy(True)
         try:
-            fragment = translate_query(query)
+            fragment = translate_query(query, file_alias="f")
         except ValueError as exc:
             self._status_label.setText(str(exc))
             self._set_busy(False)

--- a/tests/core/test_query_to_sql.py
+++ b/tests/core/test_query_to_sql.py
@@ -7,6 +7,7 @@ from core.query import translate_query
 
 def test_translate_query_single_token() -> None:
     fragment = translate_query("1girl")
+    assert "ft.file_id = f.id" in fragment.where
     assert "t.name" in fragment.where
     assert fragment.params == ["1girl"]
 

--- a/tests/db/test_repository_search.py
+++ b/tests/db/test_repository_search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from core.query import translate_query
 from db.connection import get_conn
 from db.repository import search_files
 from db.schema import apply_schema
@@ -85,3 +86,13 @@ def test_search_files_order_limit_offset(conn) -> None:
 
     second = search_files(conn, where_sql, [], order_by="f.mtime ASC", limit=1, offset=1)
     assert second[0]["id"] == file_d
+
+
+def test_translate_query_integrates_with_search(conn) -> None:
+    file_id = _insert_file(conn, path="E.png", size=111, mtime=10.0, sha="e")
+    _insert_tag(conn, "1girl", 0.88, file_id)
+
+    fragment = translate_query("1girl", file_alias="f")
+    results = search_files(conn, fragment.where, fragment.params)
+
+    assert [row["id"] for row in results] == [file_id]


### PR DESCRIPTION
## Summary
- allow specifying a file table alias when compiling tag queries to SQL
- wire the default `f` alias through the tags tab search path
- add tests to cover the generated SQL and repository integration

## Testing
- PYTHONPATH=src pytest tests/core/test_query_to_sql.py tests/db/test_repository_search.py


------
https://chatgpt.com/codex/tasks/task_e_68d43d8ccb80832384f38a7391af8019