### PR TITLE
Add WD14 tag autocomplete to Tags tab

### DIFF
--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -92,6 +92,18 @@ def get_file_by_path(conn: sqlite3.Connection, path: str) -> sqlite3.Row | None:
     return cursor.fetchone()
 
 
+def list_tag_names(conn: sqlite3.Connection, limit: int = 0) -> list[str]:
+    """Return tag names ordered alphabetically, optionally limited."""
+
+    sql = "SELECT name FROM tags ORDER BY name ASC"
+    params: tuple[object, ...] = ()
+    if limit > 0:
+        sql += " LIMIT ?"
+        params = (int(limit),)
+    cursor = conn.execute(sql, params)
+    return [str(row[0]) for row in cursor.fetchall()]
+
+
 def upsert_tags(conn: sqlite3.Connection, tags: Sequence[Mapping[str, Any]]) -> dict[str, int]:
     """Ensure tags exist and return a mapping from tag name to identifier."""
     results: dict[str, int] = {}

--- a/src/tagger/labels_util.py
+++ b/src/tagger/labels_util.py
@@ -1,0 +1,152 @@
+"""Helpers for working with WD14 label CSV files."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from tagger.base import TagCategory
+
+
+_DEFAULT_TAG_FILENAMES: tuple[str, ...] = (
+    "selected_tags.csv",
+    "selected_tags_v3.csv",
+    "selected_tags_v3c.csv",
+)
+
+_CATEGORY_LOOKUP: dict[str, TagCategory] = {
+    "0": TagCategory.GENERAL,
+    "general": TagCategory.GENERAL,
+    "1": TagCategory.CHARACTER,
+    "character": TagCategory.CHARACTER,
+    "2": TagCategory.RATING,
+    "rating": TagCategory.RATING,
+    "3": TagCategory.COPYRIGHT,
+    "copyright": TagCategory.COPYRIGHT,
+    "4": TagCategory.ARTIST,
+    "artist": TagCategory.ARTIST,
+    "5": TagCategory.META,
+    "meta": TagCategory.META,
+}
+
+
+def _looks_like_int(value: str) -> bool:
+    try:
+        int(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _parse_category(value: str | None) -> TagCategory:
+    if not value:
+        return TagCategory.GENERAL
+    normalised = value.strip().lower()
+    if not normalised:
+        return TagCategory.GENERAL
+    if normalised in _CATEGORY_LOOKUP:
+        return _CATEGORY_LOOKUP[normalised]
+    if _looks_like_int(normalised):
+        try:
+            return TagCategory(int(normalised))
+        except ValueError:
+            return TagCategory.GENERAL
+    return TagCategory.GENERAL
+
+
+def _iter_csv_rows(csv_path: Path) -> Iterable[list[str]]:
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle)
+        for row in reader:
+            if not row:
+                continue
+            cells = [cell.strip() for cell in row]
+            if not any(cells):
+                continue
+            if cells[0].startswith("#"):
+                continue
+            lower_first = cells[0].lower()
+            if lower_first in {"tag_id", "tagid", "id", "name", "tag"}:
+                continue
+            if len(cells) > 1 and cells[1].lower() in {"name", "tag"}:
+                continue
+            if len(cells) > 2 and cells[2].lower() in {"category"}:
+                continue
+            yield cells
+
+
+def load_selected_tags(csv_path: str | Path) -> list[tuple[str, int]]:
+    """Parse a WD14 ``selected_tags.csv`` file.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the CSV file. The file may contain either one, two or four
+        columns. Headers and comment lines starting with ``#`` are ignored.
+
+    Returns
+    -------
+    list[tuple[str, int]]
+        Tag names paired with their category as integers.
+    """
+
+    path = Path(csv_path)
+    labels: list[tuple[str, int]] = []
+    for cells in _iter_csv_rows(path):
+        name = ""
+        category = TagCategory.GENERAL
+        if len(cells) == 1:
+            name = cells[0]
+        elif len(cells) == 2:
+            first, second = cells
+            if _looks_like_int(first):
+                name = second
+            else:
+                name = first
+                category = _parse_category(second)
+        else:
+            first, second, *rest = cells
+            if _looks_like_int(first) and second:
+                name = second
+                category_value = rest[0] if rest else None
+                category = _parse_category(category_value)
+            else:
+                name = first
+                category = _parse_category(second if second else None)
+        if name:
+            labels.append((name, int(category)))
+    return labels
+
+
+def discover_labels_csv(
+    model_path: str | Path | None, tags_csv: str | Path | None
+) -> Path | None:
+    """Return the path to a WD14 labels CSV if one can be located."""
+
+    if tags_csv:
+        candidate = Path(tags_csv)
+        return candidate if candidate.exists() else None
+    if not model_path:
+        return None
+    model_file = Path(model_path)
+    search_dir = model_file.parent
+    candidates: list[Path] = []
+    for name in _DEFAULT_TAG_FILENAMES:
+        candidate = search_dir / name
+        if candidate not in candidates:
+            candidates.append(candidate)
+    model_candidate = model_file.with_suffix(".csv")
+    if model_candidate not in candidates:
+        candidates.append(model_candidate)
+    for extra in sorted(search_dir.glob("selected_tags*.csv")):
+        if extra not in candidates:
+            candidates.append(extra)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+__all__ = ["discover_labels_csv", "load_selected_tags"]
+

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -90,6 +90,7 @@ else:
     QGuiApplication.setAttribute(Qt.ApplicationAttribute.AA_UseSoftwareOpenGL)
 
     from db.connection import bootstrap_if_needed
+    from core.settings import PipelineSettings
     from ui.dup_tab import DupTab
     from ui.settings_tab import SettingsTab
     from ui.tags_tab import TagsTab
@@ -106,9 +107,13 @@ else:
             bootstrap_if_needed(db_path)
             self.setWindowTitle("kobato-eyes")
             self._tabs = QTabWidget()
-            self._tabs.addTab(TagsTab(self), "Tags")
-            self._tabs.addTab(DupTab(self), "Duplicates")
-            self._tabs.addTab(SettingsTab(self), "Settings")
+            self._tags_tab = TagsTab(self)
+            self._dup_tab = DupTab(self)
+            self._settings_tab = SettingsTab(self)
+            self._settings_tab.settings_applied.connect(self._on_settings_applied)
+            self._tabs.addTab(self._tags_tab, "Tags")
+            self._tabs.addTab(self._dup_tab, "Duplicates")
+            self._tabs.addTab(self._settings_tab, "Settings")
             self.setCentralWidget(self._tabs)
             self._init_menus()
 
@@ -122,6 +127,9 @@ else:
             log_dir = get_log_dir()
             log_dir.mkdir(parents=True, exist_ok=True)
             QDesktopServices.openUrl(QUrl.fromLocalFile(str(log_dir)))
+
+        def _on_settings_applied(self, settings: PipelineSettings) -> None:
+            self._tags_tab.reload_autocomplete(settings)
 
 
     def run() -> None:

--- a/src/ui/autocomplete.py
+++ b/src/ui/autocomplete.py
@@ -1,0 +1,40 @@
+"""Pure utility helpers for the tag autocomplete logic."""
+
+from __future__ import annotations
+
+import re
+
+_LAST_TOKEN_RE = re.compile(r"([A-Za-z0-9_:+><=.]+)$")
+
+
+def extract_completion_token(
+    text: str, cursor_position: int | None = None
+) -> tuple[str, int, int]:
+    """Return the trailing token within ``text`` and its range."""
+
+    if cursor_position is None:
+        cursor_position = len(text)
+    cursor_position = max(0, min(cursor_position, len(text)))
+    prefix = text[:cursor_position]
+    match = _LAST_TOKEN_RE.search(prefix)
+    if not match:
+        return "", cursor_position, cursor_position
+    start = match.start(1)
+    end = match.end(1)
+    return match.group(1), start, end
+
+
+def replace_completion_token(
+    text: str, start: int, end: int, replacement: str
+) -> tuple[str, int]:
+    """Replace the substring in ``text`` and return the new text and cursor."""
+
+    start = max(0, min(start, len(text)))
+    end = max(start, min(end, len(text)))
+    new_text = f"{text[:start]}{replacement}{text[end:]}"
+    new_cursor = start + len(replacement)
+    return new_text, new_cursor
+
+
+__all__ = ["extract_completion_token", "replace_completion_token"]
+

--- a/tests/ui/test_autocomplete_tokens.py
+++ b/tests/ui/test_autocomplete_tokens.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tagger.labels_util import load_selected_tags
+from ui.autocomplete import extract_completion_token, replace_completion_token
+
+
+def test_extract_completion_token_basic() -> None:
+    text = "solo AND ch"
+    token, start, end = extract_completion_token(text)
+    assert token == "ch"
+    assert text[start:end] == "ch"
+
+
+def test_extract_completion_token_with_cursor() -> None:
+    text = "solo AND ch"
+    token, start, end = extract_completion_token(text, cursor_position=4)
+    assert token == "solo"
+    assert (start, end) == (0, 4)
+
+
+def test_replace_completion_token() -> None:
+    text = "solo AND ch"
+    token, start, end = extract_completion_token(text)
+    assert token == "ch"
+    new_text, cursor = replace_completion_token(text, start, end, "character:")
+    assert new_text == "solo AND character:"
+    assert cursor == len(new_text)
+
+
+def test_load_selected_tags_single_column(tmp_path: Path) -> None:
+    csv_path = tmp_path / "selected_tags_single.csv"
+    csv_path.write_text("# comment\nname\n1girl\n\n", encoding="utf-8")
+    tags = load_selected_tags(csv_path)
+    assert tags == [("1girl", 0)]
+
+
+def test_load_selected_tags_two_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "selected_tags_two.csv"
+    csv_path.write_text("123,1girl\ncharacter:kobato,character\n", encoding="utf-8")
+    tags = load_selected_tags(csv_path)
+    assert ("1girl", 0) in tags
+    assert ("character:kobato", 1) in tags
+
+
+def test_load_selected_tags_four_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "selected_tags_four.csv"
+    csv_path.write_text("1,solo,0,1000\n2,artist:name,4,50\n", encoding="utf-8")
+    tags = load_selected_tags(csv_path)
+    assert ("solo", 0) in tags
+    assert ("artist:name", 4) in tags

--- a/tests/ui/test_index_now_headless.py
+++ b/tests/ui/test_index_now_headless.py
@@ -68,7 +68,7 @@ def test_index_now_async_flow(tags_tab: TagsTab, qapp: QApplication) -> None:
 
             assert not tags_tab._placeholder_button.isEnabled()  # type: ignore[attr-defined]
             assert not tags_tab._search_button.isEnabled()  # type: ignore[attr-defined]
-            assert not tags_tab._query_input.isEnabled()  # type: ignore[attr-defined]
+            assert not tags_tab._query_edit.isEnabled()  # type: ignore[attr-defined]
 
             allow_finish.set()
 


### PR DESCRIPTION
## Summary
- add reusable utilities to load WD14 tag CSVs and discover the selected_tags file near a model
- surface database tag names and WD14 labels as autocomplete candidates in the Tags tab search box
- wire Settings changes to refresh autocomplete suggestions and cover the new helpers with unit tests

## Testing
- PYTHONPATH=src pytest -m "not gui"


------
https://chatgpt.com/codex/tasks/task_e_68d461be682483239c0f48b6a2c3d206