### PR TITLE
Show all tags in Tags tab

### DIFF
--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -210,10 +210,10 @@ def search_files(
         file_id = row["id"]
         tag_rows = conn.execute(
             "SELECT t.name, ft.score FROM file_tags ft JOIN tags t ON t.id = ft.tag_id "
-            "WHERE ft.file_id = ? ORDER BY ft.score DESC LIMIT 5",
+            "WHERE ft.file_id = ? ORDER BY ft.score DESC",
             (file_id,),
         ).fetchall()
-        top_tags = [(tag_row["name"], float(tag_row["score"])) for tag_row in tag_rows]
+        tags = [(tag_row["name"], float(tag_row["score"])) for tag_row in tag_rows]
         results.append(
             {
                 "id": file_id,
@@ -222,7 +222,8 @@ def search_files(
                 "height": row["height"],
                 "size": row["size"],
                 "mtime": row["mtime"],
-                "top_tags": top_tags,
+                "tags": tags,
+                "top_tags": tags,
             }
         )
     return results

--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -274,7 +274,7 @@ class TagsTab(QWidget):
             "Size",
             "Dim",
             "Modified",
-            "Top 5 Tags",
+            "Tags",
         ]
         self._table_model = QStandardItemModel(0, len(headers), self)
         self._table_model.setHorizontalHeaderLabels(headers)
@@ -711,6 +711,8 @@ class TagsTab(QWidget):
             row_index = len(self._results_cache)
             self._results_cache.append(record)
             path_obj = Path(str(record.get("path", "")))
+            tags = list(record.get("tags") or record.get("top_tags") or [])
+            tags_text = self._format_tags(tags)
 
             table_items = [
                 QStandardItem(""),
@@ -719,23 +721,25 @@ class TagsTab(QWidget):
                 QStandardItem(self._format_size(record.get("size"))),
                 QStandardItem(self._format_dimensions(record.get("width"), record.get("height"))),
                 QStandardItem(self._format_mtime(record.get("mtime"))),
-                QStandardItem(self._format_tags(record.get("top_tags", []))),
+                QStandardItem(tags_text),
             ]
             table_items[0].setData(
                 Qt.AlignmentFlag.AlignCenter, Qt.ItemDataRole.TextAlignmentRole
             )
             for item in table_items:
                 item.setEditable(False)
+            table_items[-1].setToolTip(tags_text)
             self._table_model.appendRow(table_items)
             self._table_view.setRowHeight(row_index, self._THUMB_SIZE + 16)
 
-            grid_item = QStandardItem(self._format_grid_text(path_obj.name, record.get("top_tags", [])))
+            grid_item = QStandardItem(self._format_grid_text(path_obj.name, tags))
             grid_item.setEditable(False)
             grid_item.setData(row_index, Qt.ItemDataRole.UserRole)
             grid_item.setData(
                 Qt.AlignmentFlag.AlignCenter, Qt.ItemDataRole.TextAlignmentRole
             )
             grid_item.setSizeHint(QSize(self._THUMB_SIZE + 48, self._THUMB_SIZE + 72))
+            grid_item.setToolTip(tags_text)
             self._grid_model.appendRow(grid_item)
 
             if path_obj.exists():

--- a/tests/db/test_repository_search.py
+++ b/tests/db/test_repository_search.py
@@ -68,10 +68,11 @@ def test_search_files_returns_expected_record(conn) -> None:
     assert record["width"] is None and record["height"] is None
     assert record["size"] == 123
     assert record["mtime"] == pytest.approx(200.0)
-    assert len(record["top_tags"]) == 5
-    names = [name for name, _ in record["top_tags"]]
-    assert names[0] == "1girl"
-    assert "outdoors" not in names
+    assert "tags" in record
+    assert len(record["tags"]) == len(tags)
+    tag_names = [name for name, _ in record["tags"]]
+    assert tag_names == [name for name, _ in tags]
+    assert record["top_tags"] == record["tags"]
 
 
 def test_search_files_order_limit_offset(conn) -> None:


### PR DESCRIPTION
## Summary
- remove the per-file tag limit in `search_files` and expose a new `tags` field alongside the legacy `top_tags`
- update the tags tab table to use the full tag list, rename the column to "Tags", and surface the values in tooltips
- extend the repository search test to verify the new `tags` payload retains ordering and backward compatibility

## Testing
- PYTHONPATH=src pytest -m "not gui"


------
https://chatgpt.com/codex/tasks/task_e_68d48306eba88323aec5a48bad539afa