### PR TITLE
Add database reset functionality with UI integration

### DIFF
--- a/src/db/admin.py
+++ b/src/db/admin.py
@@ -1,0 +1,97 @@
+"""Administrative helpers for managing the kobato-eyes database file."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from db import connection as db_connection
+from utils.paths import get_index_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_path(db_path: str | Path) -> Path:
+    path = Path(db_path).expanduser()
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path.absolute()
+
+
+def _copy_backup(source: Path, suffix: str) -> Path:
+    destination = source.with_name(f"{source.name}.{suffix}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination
+
+
+def _format_backup_suffix() -> str:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return f"bak-{timestamp}"
+
+
+def _reset_bootstrap_cache(original: str | Path, resolved: Path) -> None:
+    db_connection._BOOTSTRAPPED.discard(str(original))
+    db_connection._BOOTSTRAPPED.discard(str(resolved))
+
+
+def reset_database(
+    db_path: str | Path,
+    *,
+    backup: bool = True,
+    purge_hnsw: bool = True,
+) -> dict[str, object]:
+    """Reset the SQLite database and associated artifacts.
+
+    The caller must ensure that all active connections to the target database are
+    closed before invoking this function.
+    """
+
+    resolved_path = _resolve_path(db_path)
+    wal_path = resolved_path.with_name(f"{resolved_path.name}-wal")
+    shm_path = resolved_path.with_name(f"{resolved_path.name}-shm")
+
+    backup_paths: list[Path] = []
+    if backup:
+        suffix = _format_backup_suffix()
+        for candidate in (resolved_path, wal_path, shm_path):
+            if candidate.exists():
+                try:
+                    backup_paths.append(_copy_backup(candidate, suffix))
+                except OSError:
+                    logger.exception("Failed to backup %s", candidate)
+                    raise
+
+    for candidate in (resolved_path, wal_path, shm_path):
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError:
+            logger.exception("Failed to remove %s", candidate)
+            raise
+
+    hnsw_deleted = False
+    if purge_hnsw:
+        try:
+            index_dir = get_index_dir()
+            hnsw_path = index_dir / "hnsw_cosine.bin"
+            if hnsw_path.exists():
+                hnsw_path.unlink()
+                hnsw_deleted = True
+        except OSError:
+            logger.exception("Failed to remove HNSW index file")
+            raise
+
+    _reset_bootstrap_cache(db_path, resolved_path)
+    db_connection.bootstrap_if_needed(resolved_path)
+
+    return {
+        "db": resolved_path,
+        "backup_paths": backup_paths,
+        "hnsw_deleted": hnsw_deleted,
+    }
+
+
+__all__ = ["reset_database"]

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -111,6 +111,7 @@ else:
             self._dup_tab = DupTab(self)
             self._settings_tab = SettingsTab(self)
             self._settings_tab.settings_applied.connect(self._on_settings_applied)
+            self._settings_tab.set_tags_tab(self._tags_tab)
             self._tabs.addTab(self._tags_tab, "Tags")
             self._tabs.addTab(self._dup_tab, "Duplicates")
             self._tabs.addTab(self._settings_tab, "Settings")

--- a/tests/db/test_reset_database.py
+++ b/tests/db/test_reset_database.py
@@ -1,0 +1,118 @@
+"""Tests for :mod:`db.admin` database reset helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from db.admin import reset_database
+from db.connection import get_conn
+from db.repository import replace_file_tags, upsert_file, upsert_tags
+from db.schema import CURRENT_SCHEMA_VERSION
+
+pytestmark = pytest.mark.not_gui
+
+
+def _table_count(conn: sqlite3.Connection, table: str) -> int:
+    cursor = conn.execute(f"SELECT COUNT(*) FROM {table}")
+    try:
+        value = cursor.fetchone()[0]
+    finally:
+        cursor.close()
+    return int(value)
+
+
+def test_reset_creates_empty_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "library.db"
+    conn = get_conn(db_path)
+    try:
+        file_id = upsert_file(
+            conn,
+            path="/images/sample.png",
+            size=1024,
+            mtime=123.45,
+            sha256="deadbeef",
+        )
+        tags = upsert_tags(
+            conn,
+            [
+                {"name": "tag:one", "category": 0},
+                {"name": "tag:two", "category": 1},
+            ],
+        )
+        replace_file_tags(
+            conn,
+            file_id,
+            [(tags["tag:one"], 0.9), (tags["tag:two"], 0.6)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = reset_database(db_path, backup=False, purge_hnsw=False)
+    assert Path(result["db"]) == db_path
+
+    fresh = get_conn(db_path)
+    try:
+        for table in ["files", "tags", "file_tags", "signatures", "embeddings"]:
+            assert _table_count(fresh, table) == 0
+        version = fresh.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        fresh.close()
+
+    assert int(version) == CURRENT_SCHEMA_VERSION
+
+
+def test_reset_with_backup_and_hnsw(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "kobato-eyes.db"
+    conn = get_conn(db_path)
+    try:
+        conn.execute("INSERT INTO tags (name) VALUES ('existing')")
+        conn.commit()
+    finally:
+        conn.close()
+
+    wal_path = db_path.with_name(f"{db_path.name}-wal")
+    wal_path.write_bytes(b"wal")
+    shm_path = db_path.with_name(f"{db_path.name}-shm")
+    shm_path.write_bytes(b"shm")
+
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    hnsw_path = index_dir / "hnsw_cosine.bin"
+    hnsw_path.write_bytes(b"index")
+
+    monkeypatch.setattr("db.admin.get_index_dir", lambda: index_dir)
+
+    result = reset_database(db_path, backup=True, purge_hnsw=True)
+
+    backups = result["backup_paths"]
+    assert isinstance(backups, list)
+    assert len(backups) == 3
+    for backup in backups:
+        assert isinstance(backup, Path)
+        assert backup.exists()
+
+    expected_prefixes = {f"{p.name}.bak-" for p in (db_path, wal_path, shm_path)}
+    matched_prefixes = {
+        prefix
+        for path in backups
+        for prefix in expected_prefixes
+        if path.name.startswith(prefix)
+    }
+    assert matched_prefixes == expected_prefixes
+
+    assert result["hnsw_deleted"] is True
+    assert not hnsw_path.exists()
+
+    fresh = get_conn(db_path)
+    try:
+        count = _table_count(fresh, "tags")
+    finally:
+        fresh.close()
+
+    assert count == 0


### PR DESCRIPTION
## Summary
- add `db.admin.reset_database` to rebuild the SQLite database with optional backups and HNSW purging
- expose a reset dialog from the settings tab that coordinates with the tags tab and optionally restarts indexing
- cover the reset workflow with new headless tests that verify schema recreation and backup handling

## Testing
- `KOE_HEADLESS=1 PYTHONPATH=src pytest -m "not gui"`


------
https://chatgpt.com/codex/tasks/task_e_68d4c72b795883239025cfcdfecdf271