### PR TITLE
Apply category thresholds during tag search

### DIFF
--- a/src/core/query.py
+++ b/src/core/query.py
@@ -290,9 +290,7 @@ def _compile_expression(
             )
             return clause, [expr.name]
         else:
-            general_thr, character_thr, copyright_thr, default_thr = (
-                _threshold_tuple(thresholds)
-            )
+            general_thr, character_thr, copyright_thr, default_thr = _threshold_tuple(thresholds)
             clause = (
                 "EXISTS ("
                 "SELECT 1 FROM file_tags ft JOIN tags t ON t.id = ft.tag_id "
@@ -300,7 +298,7 @@ def _compile_expression(
                 "AND t.name = ? "
                 "AND ft.score >= CASE t.category "
                 "WHEN 0 THEN ? "
-                "WHEN 1 THEN ? "
+                "WHEN 4 THEN ? "
                 "WHEN 3 THEN ? "
                 "ELSE ? "
                 "END)"

--- a/src/core/query.py
+++ b/src/core/query.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import shlex
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Mapping, Sequence
 
 from tagger.base import TagCategory
 
@@ -230,29 +230,100 @@ class _Parser:
         }
 
 
-def _build_sql(expr: _Expression | None, *, file_alias: str = "f") -> QueryFragment:
+_FALLBACK_THRESHOLDS: dict[int, float] = {
+    0: 0.35,
+    1: 0.25,
+    3: 0.25,
+    -1: 0.0,
+}
+
+
+def _normalize_thresholds(
+    thresholds: Mapping[int, float] | None,
+) -> dict[int, float]:
+    mapping = dict(_FALLBACK_THRESHOLDS)
+    if thresholds:
+        for key, value in thresholds.items():
+            try:
+                mapping[int(key)] = float(value)
+            except (TypeError, ValueError):
+                continue
+    return mapping
+
+
+def _threshold_tuple(
+    thresholds: Mapping[int, float] | None,
+) -> tuple[float, float, float, float]:
+    normalized = _normalize_thresholds(thresholds)
+    return (
+        normalized.get(0, 0.0),
+        normalized.get(1, 0.0),
+        normalized.get(3, 0.0),
+        normalized.get(-1, 0.0),
+    )
+
+
+def _build_sql(
+    expr: _Expression | None,
+    *,
+    file_alias: str = "f",
+    thresholds: Mapping[int, float] | None = None,
+) -> QueryFragment:
     if expr is None:
         return QueryFragment(where="1=1", params=[])
 
-    where, params = _compile_expression(expr, file_alias=file_alias)
+    where, params = _compile_expression(
+        expr,
+        file_alias=file_alias,
+        thresholds=thresholds,
+    )
     return QueryFragment(where=where, params=params)
 
 
-def _compile_expression(expr: _Expression, *, file_alias: str) -> tuple[str, list[object]]:
+def _compile_expression(
+    expr: _Expression,
+    *,
+    file_alias: str,
+    thresholds: Mapping[int, float] | None,
+) -> tuple[str, list[object]]:
     if isinstance(expr, _TagExpr):
+        general_thr, character_thr, copyright_thr, default_thr = _threshold_tuple(
+            thresholds
+        )
         clause = (
             "EXISTS ("
             "SELECT 1 FROM file_tags ft JOIN tags t ON t.id = ft.tag_id "
-            f"WHERE ft.file_id = {file_pk(file_alias)} AND t.name = ?)"
+            f"WHERE ft.file_id = {file_pk(file_alias)} "
+            "AND t.name = ? "
+            "AND ft.score >= CASE t.category "
+            "WHEN 0 THEN ? "
+            "WHEN 1 THEN ? "
+            "WHEN 3 THEN ? "
+            "ELSE ? "
+            "END)"
         )
-        return clause, [expr.name]
+        return (
+            clause,
+            [
+                expr.name,
+                general_thr,
+                character_thr,
+                copyright_thr,
+                default_thr,
+            ],
+        )
     if isinstance(expr, _CategoryExpr):
+        normalized = _normalize_thresholds(thresholds)
+        category_key = int(expr.category)
+        threshold_value = float(normalized.get(category_key, 0.0))
         clause = (
             "EXISTS ("
             "SELECT 1 FROM file_tags ft JOIN tags t ON t.id = ft.tag_id "
-            f"WHERE ft.file_id = {file_pk(file_alias)} AND t.category = ?)"
+            f"WHERE ft.file_id = {file_pk(file_alias)} "
+            "AND t.category = ? "
+            "AND ft.score >= ?)"
         )
-        return clause, [int(expr.category)]
+        return clause, [category_key, threshold_value]
     if isinstance(expr, _ScoreExpr):
         clause = (
             "EXISTS (SELECT 1 FROM file_tags ft "
@@ -260,23 +331,40 @@ def _compile_expression(expr: _Expression, *, file_alias: str) -> tuple[str, lis
         )
         return clause, [expr.threshold]
     if isinstance(expr, _UnaryExpr):
-        inner, params = _compile_expression(expr.operand, file_alias=file_alias)
+        inner, params = _compile_expression(
+            expr.operand,
+            file_alias=file_alias,
+            thresholds=thresholds,
+        )
         return f"NOT ({inner})", params
     if isinstance(expr, _BinaryExpr):
-        left_sql, left_params = _compile_expression(expr.left, file_alias=file_alias)
-        right_sql, right_params = _compile_expression(expr.right, file_alias=file_alias)
+        left_sql, left_params = _compile_expression(
+            expr.left,
+            file_alias=file_alias,
+            thresholds=thresholds,
+        )
+        right_sql, right_params = _compile_expression(
+            expr.right,
+            file_alias=file_alias,
+            thresholds=thresholds,
+        )
         combined = f"({left_sql}) {expr.op} ({right_sql})"
         return combined, left_params + right_params
 
     raise TypeError(f"Unhandled expression type: {expr}")
 
 
-def translate_query(query: str, *, file_alias: str = "f") -> QueryFragment:
+def translate_query(
+    query: str,
+    *,
+    file_alias: str = "f",
+    thresholds: Mapping[int, float] | None = None,
+) -> QueryFragment:
     """Convert a simplified tag query string into an SQL WHERE fragment."""
     tokens = _tokenize(query)
     parser = _Parser(tokens)
     expr = parser.parse()
-    return _build_sql(expr, file_alias=file_alias)
+    return _build_sql(expr, file_alias=file_alias, thresholds=thresholds)
 
 
 __all__ = ["QueryFragment", "file_pk", "translate_query"]

--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -978,8 +978,16 @@ class TagsTab(QWidget):
         query = self._query_edit.text().strip()
         self._highlight_terms = _extract_positive_terms(query) if query else []
         self._set_busy(True)
+        thresholds = {
+            int(category): float(value)
+            for category, value in (self._tag_thresholds or {}).items()
+        }
         try:
-            fragment = translate_query(query, file_alias="f")
+            fragment = translate_query(
+                query,
+                file_alias="f",
+                thresholds=thresholds,
+            )
         except ValueError as exc:
             self._status_label.setText(str(exc))
             self._set_busy(False)


### PR DESCRIPTION
## Summary
- propagate optional per-category threshold mapping through `translate_query`
- guard tag and category expressions with CASE/threshold filters that fall back to defaults
- pass the UI-configured thresholds into the query translator so low-score rows are excluded

## Testing
- `pytest` *(fails: missing optional modules such as `hypothesis`, `tagger.labels_util`, and `ui.autocomplete` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d573702b80832386693e4ac4bfb808