### PR TITLE
タグの確信度が高い順にヒット

### DIFF
--- a/tests/core/test_query_terms.py
+++ b/tests/core/test_query_terms.py
@@ -1,0 +1,26 @@
+"""Tests for extracting positive tag terms from queries."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.query import extract_positive_tag_terms
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("", []),
+        ("haruhi", ["haruhi"]),
+        ("Haruhi", ["haruhi"]),
+        ("haruhi OR miku", ["haruhi", "miku"]),
+        ("a AND (b OR NOT c)", ["a", "b"]),
+        ("NOT haruhi", []),
+        ("character: AND miku", ["miku"]),
+        ("miku AND NOT (rin OR NOT luka)", ["miku", "luka"]),
+    ],
+)
+def test_extract_positive_tag_terms(query: str, expected: list[str]) -> None:
+    """Positive tags should be collected in sorted, lower-cased order."""
+
+    assert extract_positive_tag_terms(query) == expected

--- a/tests/db/test_repository_relevance.py
+++ b/tests/db/test_repository_relevance.py
@@ -1,0 +1,90 @@
+"""Tests for relevance-based ordering in ``search_files``."""
+
+from __future__ import annotations
+
+import pytest
+
+from db.connection import get_conn
+from db.repository import search_files
+from db.schema import apply_schema
+
+
+@pytest.fixture()
+def conn():
+    connection = get_conn(":memory:")
+    apply_schema(connection)
+    yield connection
+    connection.close()
+
+
+def _insert_file(connection, *, path: str, size: int, mtime: float, sha: str) -> int:
+    cursor = connection.execute(
+        "INSERT INTO files (path, size, mtime, sha256) VALUES (?, ?, ?, ?)",
+        (path, size, mtime, sha),
+    )
+    return int(cursor.lastrowid)
+
+
+def _insert_tag(
+    connection,
+    name: str,
+    score: float,
+    file_id: int,
+    *,
+    category: int = 0,
+) -> None:
+    cursor = connection.execute(
+        "INSERT INTO tags (name, category) VALUES (?, ?) "
+        "ON CONFLICT(name) DO UPDATE SET category = excluded.category "
+        "RETURNING id",
+        (name, category),
+    )
+    tag_id = cursor.fetchone()[0]
+    connection.execute(
+        "INSERT INTO file_tags (file_id, tag_id, score) VALUES (?, ?, ?)",
+        (file_id, tag_id, score),
+    )
+
+
+def test_search_files_orders_by_relevance(conn) -> None:
+    high = _insert_file(conn, path="high.png", size=1, mtime=10.0, sha="h")
+    low = _insert_file(conn, path="low.png", size=1, mtime=20.0, sha="l")
+
+    _insert_tag(conn, "haruhi", 0.9, high)
+    _insert_tag(conn, "haruhi", 0.2, low)
+
+    rows = search_files(
+        conn,
+        "1=1",
+        [],
+        tags_for_relevance=["haruhi"],
+        thresholds={0: 0.0},
+        order="relevance",
+    )
+
+    assert [row["id"] for row in rows] == [high, low]
+    assert rows[0]["relevance"] == pytest.approx(0.9)
+    assert rows[1]["relevance"] == pytest.approx(0.2)
+
+
+def test_search_files_aggregates_scores_for_multiple_tags(conn) -> None:
+    file_a = _insert_file(conn, path="a.png", size=1, mtime=5.0, sha="a")
+    file_b = _insert_file(conn, path="b.png", size=1, mtime=6.0, sha="b")
+
+    _insert_tag(conn, "haruhi", 0.8, file_a)
+    _insert_tag(conn, "miku", 0.1, file_a)
+    _insert_tag(conn, "haruhi", 0.5, file_b)
+    _insert_tag(conn, "miku", 0.5, file_b)
+
+    rows = search_files(
+        conn,
+        "1=1",
+        [],
+        tags_for_relevance=["haruhi", "miku"],
+        thresholds={0: 0.0},
+        order="relevance",
+    )
+
+    assert [row["id"] for row in rows] == [file_b, file_a]
+    assert rows[0]["relevance"] == pytest.approx(1.0)
+    assert rows[1]["relevance"] == pytest.approx(0.9)

--- a/tests/db/test_repository_search.py
+++ b/tests/db/test_repository_search.py
@@ -70,6 +70,7 @@ def test_search_files_returns_expected_record(conn) -> None:
     assert record["path"] == "A.png"
     assert record["width"] is None and record["height"] is None
     assert record["size"] == 123
+    assert record["relevance"] == pytest.approx(0.0)
     assert record["mtime"] == pytest.approx(200.0)
     assert "tags" in record
     assert len(record["tags"]) == len(tags)


### PR DESCRIPTION
## Summary
- add query-term extraction helper for positive tag names and cover it with unit tests
- compute relevance scores during file search, returning the value and supporting score-based ordering
- update the tag search UI to request relevance ordering, load thresholds, and highlight exact tag matches

## Testing
- PYTHONPATH=src pytest tests/core/test_query_terms.py tests/db/test_repository_relevance.py tests/db/test_repository_search.py
- PYTHONPATH=src pytest src/kobato-eyes/tests/db/test_repository_search.py --rootdir=src/kobato-eyes -q

------
https://chatgpt.com/codex/tasks/task_e_68d65401d5d883238b850286dc703c17