### PR TITLE
手動スキャン

### DIFF
--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -80,6 +80,9 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE INDEX IF NOT EXISTS idx_embeddings_model ON embeddings(model);
     """,
+    """
+    CREATE INDEX IF NOT EXISTS files_path_idx ON files(path);
+    """,
 )
 
 


### PR DESCRIPTION
## Summary
- add a tagging-only `scan_and_tag` pipeline entry point with logging and folder scoping
- expose database helpers and an index to list untagged paths efficiently
- add a Tags tab refresh button that runs the scan asynchronously and updates the UI

## Testing
- PYTHONPATH=src pytest *(fails: missing hypothesis and system libGL)*

------
https://chatgpt.com/codex/tasks/task_e_68d7377cd93083239f407a185be9717e