### PR TITLE
NOT検索をハイフン"-"でもできるように（失敗）

### DIFF
--- a/src/core/search_parser.py
+++ b/src/core/search_parser.py
@@ -1,0 +1,89 @@
+"""Parse lightweight tag search expressions."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from typing import Mapping
+
+from tagger.base import TagCategory
+
+_TAG_PATTERN = re.compile(r"^[A-Za-z0-9:_\-!?><.@()^+]+$")
+
+_CATEGORY_ALIASES: Mapping[str, TagCategory] = {
+    "0": TagCategory.GENERAL,
+    "general": TagCategory.GENERAL,
+    "1": TagCategory.CHARACTER,
+    "character": TagCategory.CHARACTER,
+    "2": TagCategory.RATING,
+    "rating": TagCategory.RATING,
+    "3": TagCategory.COPYRIGHT,
+    "copyright": TagCategory.COPYRIGHT,
+    "4": TagCategory.ARTIST,
+    "artist": TagCategory.ARTIST,
+    "5": TagCategory.META,
+    "meta": TagCategory.META,
+}
+
+
+@dataclass(frozen=True)
+class TagSpec:
+    """Single tag term extracted from a user query."""
+
+    name: str
+    category: TagCategory | None = None
+
+
+def _parse_tag(text: str) -> TagSpec | None:
+    if not text or text == "-":
+        return None
+    if not _TAG_PATTERN.fullmatch(text):
+        return None
+    category: TagCategory | None = None
+    if ":" in text:
+        prefix, rest = text.split(":", 1)
+        if rest:
+            alias = prefix.lower()
+            category = _CATEGORY_ALIASES.get(alias)
+    return TagSpec(name=text, category=category)
+
+
+def parse_search(expr: str) -> dict[str, list[TagSpec] | list[str]]:
+    """Parse ``expr`` into tag filters and free-text terms."""
+
+    tokens = shlex.split(expr, posix=True) if expr else []
+    include: list[TagSpec] = []
+    exclude: list[TagSpec] = []
+    free: list[str] = []
+
+    skip_next = False
+    for raw in tokens:
+        if not raw:
+            continue
+        if skip_next:
+            free.append(raw)
+            skip_next = False
+            continue
+        if raw == "-":
+            free.append(raw)
+            skip_next = True
+            continue
+        if raw.startswith("-") and len(raw) > 1:
+            candidate = raw[1:]
+            spec = _parse_tag(candidate)
+            if spec is not None:
+                exclude.append(spec)
+            else:
+                free.append(raw)
+            continue
+        spec = _parse_tag(raw)
+        if spec is not None:
+            include.append(spec)
+        else:
+            free.append(raw)
+
+    return {"include": include, "exclude": exclude, "free": free}
+
+
+__all__ = ["TagSpec", "parse_search"]

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -6,6 +6,8 @@ import sqlite3
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
+from core.search_parser import TagSpec
+
 _CATEGORY_KEY_LOOKUP = {
     "0": 0,
     "general": 0,
@@ -397,6 +399,76 @@ def search_files(
     return results
 
 
+def _build_tag_exists(tag: TagSpec, *, file_alias: str) -> tuple[str, list[object]]:
+    conditions = [f"ft.file_id = {file_alias}.id"]
+    params: list[object] = []
+    if tag.category is not None:
+        conditions.append("t.category = ?")
+        params.append(int(tag.category))
+    conditions.append("t.name = ?")
+    params.append(tag.name)
+    where_clause = " AND ".join(conditions)
+    clause = (
+        "EXISTS ("
+        "SELECT 1 FROM file_tags ft "
+        "JOIN tags t ON t.id = ft.tag_id "
+        f"WHERE {where_clause})"
+    )
+    return clause, params
+
+
+def build_tag_filters(
+    include: Sequence[TagSpec],
+    exclude: Sequence[TagSpec],
+    *,
+    file_alias: str = "f",
+) -> tuple[str, list[object]]:
+    """Return a WHERE clause enforcing ``include``/``exclude`` tag filters."""
+
+    clauses: list[str] = ["1=1"]
+    params: list[object] = []
+
+    for tag in include:
+        clause, clause_params = _build_tag_exists(tag, file_alias=file_alias)
+        clauses.append(f"AND {clause}")
+        params.extend(clause_params)
+
+    for tag in exclude:
+        clause, clause_params = _build_tag_exists(tag, file_alias=file_alias)
+        clauses.append(f"AND NOT {clause}")
+        params.extend(clause_params)
+
+    return " ".join(clauses), params
+
+
+def search_files_by_query(
+    conn: sqlite3.Connection,
+    terms: Mapping[str, Sequence[TagSpec] | Sequence[str]],
+    *,
+    order: str = "mtime",
+    order_by: str | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, object]]:
+    """Search files using a parsed tag query mapping."""
+
+    include_terms = tuple(terms.get("include", ()))
+    exclude_terms = tuple(terms.get("exclude", ()))
+
+    where_sql, params = build_tag_filters(include_terms, exclude_terms, file_alias="f")
+
+    return search_files(
+        conn,
+        where_sql,
+        params,
+        tags_for_relevance=[tag.name for tag in include_terms] or None,
+        order=order,
+        order_by=order_by,
+        limit=limit,
+        offset=offset,
+    )
+
+
 def mark_indexed_at(
     conn: sqlite3.Connection,
     file_id: int,
@@ -420,6 +492,8 @@ __all__ = [
     "upsert_signatures",
     "upsert_embedding",
     "search_files",
+    "search_files_by_query",
+    "build_tag_filters",
     "mark_indexed_at",
     "list_tag_names",
     "list_untagged_under_path",

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -402,9 +402,18 @@ def search_files(
 def _build_tag_exists(tag: TagSpec, *, file_alias: str) -> tuple[str, list[object]]:
     conditions = [f"ft.file_id = {file_alias}.id"]
     params: list[object] = []
+    category_id: int | None = None
     if tag.category is not None:
+        lookup_key = str(tag.category).lower()
+        category_id = _CATEGORY_KEY_LOOKUP.get(lookup_key)
+        if category_id is None:
+            try:
+                category_id = int(tag.category)
+            except (TypeError, ValueError):
+                category_id = None
+    if category_id is not None:
         conditions.append("t.category = ?")
-        params.append(int(tag.category))
+        params.append(category_id)
     conditions.append("t.name = ?")
     params.append(tag.name)
     where_clause = " AND ".join(conditions)

--- a/tests/core/test_search_parser.py
+++ b/tests/core/test_search_parser.py
@@ -1,0 +1,54 @@
+"""Tests for the lightweight search parser."""
+
+from __future__ import annotations
+
+from core.search_parser import parse_search
+from tagger.base import TagCategory
+
+
+def test_parse_search_splits_include_and_exclude() -> None:
+    result = parse_search("foo -bar half-closed_eyes")
+
+    include = result["include"]
+    exclude = result["exclude"]
+    free = result["free"]
+
+    assert [spec.name for spec in include] == ["foo", "half-closed_eyes"]
+    assert [spec.name for spec in exclude] == ["bar"]
+    assert free == []
+
+
+def test_parse_search_handles_quoted_negative() -> None:
+    result = parse_search('-"big-hair"')
+
+    include = result["include"]
+    exclude = result["exclude"]
+
+    assert include == []
+    assert [spec.name for spec in exclude] == ["big-hair"]
+
+
+def test_parse_search_ignores_spaced_minus() -> None:
+    result = parse_search("- big-hair")
+
+    assert result["include"] == []
+    assert result["exclude"] == []
+    assert result["free"] == ["-", "big-hair"]
+
+
+def test_parse_search_extracts_category_prefix() -> None:
+    result = parse_search("artist:john")
+
+    include = result["include"]
+    assert len(include) == 1
+    assert include[0].name == "artist:john"
+    assert include[0].category == TagCategory.ARTIST
+
+
+def test_parse_search_retains_unknown_prefix() -> None:
+    result = parse_search("prefix:value")
+
+    include = result["include"]
+    assert len(include) == 1
+    assert include[0].name == "prefix:value"
+    assert include[0].category is None

--- a/tests/core/test_search_parser.py
+++ b/tests/core/test_search_parser.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from core.search_parser import SearchToken, parse_search, tokenize_search
-from tagger.base import TagCategory
+from core.search_parser import identify_token_at, parse_search, strip_negative_prefix
+
+
+def _names(specs) -> list[str]:
+    return [spec.name for spec in specs]
 
 
 def test_parse_search_splits_include_and_exclude() -> None:
@@ -11,24 +14,30 @@ def test_parse_search_splits_include_and_exclude() -> None:
 
     include = result["include"]
     exclude = result["exclude"]
-    free = result["free"]
 
-    assert [spec.name for spec in include] == ["foo", "half-closed_eyes"]
-    assert [spec.name for spec in exclude] == ["bar"]
-    assert free == []
+    assert _names(include) == ["foo", "half-closed_eyes"]
+    assert _names(exclude) == ["bar"]
+    assert result["free"] == []
+
+
+def test_parse_search_supports_not_keyword() -> None:
+    result = parse_search("megurine_luka NOT hatsune_miku")
+
+    include = result["include"]
+    exclude = result["exclude"]
+
+    assert _names(include) == ["megurine_luka"]
+    assert _names(exclude) == ["hatsune_miku"]
 
 
 def test_parse_search_handles_quoted_negative() -> None:
     result = parse_search('-"big-hair"')
 
-    include = result["include"]
-    exclude = result["exclude"]
-
-    assert include == []
-    assert [spec.name for spec in exclude] == ["big-hair"]
+    assert result["include"] == []
+    assert _names(result["exclude"]) == ["big-hair"]
 
 
-def test_parse_search_ignores_spaced_minus() -> None:
+def test_parse_search_treats_spaced_minus_as_free() -> None:
     result = parse_search("- big-hair")
 
     assert result["include"] == []
@@ -41,37 +50,38 @@ def test_parse_search_extracts_category_prefix() -> None:
 
     include = result["include"]
     assert len(include) == 1
-    assert include[0].name == "artist:john"
-    assert include[0].category == TagCategory.ARTIST
+    spec = include[0]
+    assert spec.raw == "artist:john"
+    assert spec.category == "artist"
+    assert spec.name == "john"
 
 
-def test_parse_search_retains_unknown_prefix() -> None:
+def test_parse_search_leaves_unknown_prefix_as_raw() -> None:
     result = parse_search("prefix:value")
 
     include = result["include"]
     assert len(include) == 1
-    assert include[0].name == "prefix:value"
-    assert include[0].category is None
+    spec = include[0]
+    assert spec.raw == "prefix:value"
+    assert spec.category is None
+    assert spec.name == "prefix:value"
 
 
-def test_parse_search_supports_not_operator() -> None:
-    result = parse_search("megurine_luka NOT hatsune_miku")
+def test_identify_token_at_handles_various_positions() -> None:
+    text = "foo -bar baz"
+    start, end, token = identify_token_at(text, 6)
+    assert (start, end, token) == (4, 8, "-bar")
 
-    include = result["include"]
-    exclude = result["exclude"]
+    start, end, token = identify_token_at(text, 3)
+    assert (start, end, token) == (3, 3, "")
 
-    assert [spec.name for spec in include] == ["megurine_luka"]
-    assert [spec.name for spec in exclude] == ["hatsune_miku"]
+    start, end, token = identify_token_at("-hatsune", 5)
+    assert (start, end, token) == (0, 8, "-hatsune")
 
 
-def test_tokenize_search_marks_negative_tokens() -> None:
-    tokens = tokenize_search("foo -bar NOT baz - big-hair")
-
-    assert isinstance(tokens[0], SearchToken)
-    names = [token.spec.name if token.spec else token.raw for token in tokens]
-    negatives = [token.is_negative for token in tokens]
-    is_free = [token.is_free for token in tokens]
-
-    assert names == ["foo", "bar", "baz", "-", "big-hair"]
-    assert negatives == [False, True, True, False, False]
-    assert is_free == [False, False, False, True, True]
+def test_strip_negative_prefix_variants() -> None:
+    assert strip_negative_prefix("-hatsune_miku") == (True, "hatsune_miku", False)
+    assert strip_negative_prefix("hatsune_miku") == (False, "hatsune_miku", False)
+    assert strip_negative_prefix('-"big-hair"') == (True, "big-hair", True)
+    assert strip_negative_prefix("-\"") == (True, "", True)
+    assert strip_negative_prefix("\"quoted\"") == (False, "quoted", True)

--- a/tests/db/test_repository_search.py
+++ b/tests/db/test_repository_search.py
@@ -154,3 +154,17 @@ def test_search_files_by_query_treats_spaced_minus_as_free(conn) -> None:
     results = search_files_by_query(conn, terms)
 
     assert [row["id"] for row in results] == [file_a]
+
+
+def test_search_files_by_query_supports_not_keyword(conn) -> None:
+    file_a = _insert_file(conn, path="vocaloid.png", size=512, mtime=50.0, sha="v")
+    file_b = _insert_file(conn, path="duo.png", size=256, mtime=60.0, sha="d")
+
+    _insert_tag(conn, "megurine_luka", 0.95, file_a)
+    _insert_tag(conn, "hatsune_miku", 0.9, file_b)
+    _insert_tag(conn, "megurine_luka", 0.9, file_b)
+
+    terms = parse_search("megurine_luka NOT hatsune_miku")
+    results = search_files_by_query(conn, terms)
+
+    assert [row["id"] for row in results] == [file_a]


### PR DESCRIPTION
## Summary
- add a lightweight search parser that recognises negative tag tokens and optional category prefixes
- extend the repository search helpers to build EXISTS/NOT EXISTS clauses from parsed tags and expose `search_files_by_query`
- cover the new parser and repository integration with focused tests for minus-search behaviour and edge cases

## Testing
- PYTHONPATH=src pytest tests/core/test_search_parser.py tests/db/test_repository_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d74d14e95883238cedff379bb6aa87