### PR TITLE
Implement duplicate scanning workflow and UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "hnswlib>=0.8.0",
     "opencv-python-headless>=4.10.0.84",
     "scikit-image>=0.24.0",
+    "Send2Trash>=1.8.3",
     "PyYAML>=6.0",
     "SQLAlchemy>=2.0.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ safetensors==0.6.2
 scikit-image==0.25.2
 scikit-learn==1.7.2
 scipy==1.15.3
+Send2Trash==1.8.3
 SQLAlchemy==2.0.43
 sympy==1.14.0
 threadpoolctl==3.6.0

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from typing import Callable, Iterable
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
@@ -15,6 +15,7 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         size INTEGER,
         mtime REAL,
         sha256 TEXT,
+        is_present INTEGER NOT NULL DEFAULT 1,
         width INTEGER,
         height INTEGER,
         indexed_at REAL,
@@ -83,6 +84,9 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
     CREATE INDEX IF NOT EXISTS files_path_idx ON files(path);
     """,
+    """
+    CREATE INDEX IF NOT EXISTS files_is_present_path_idx ON files(is_present, path);
+    """,
 )
 
 
@@ -106,8 +110,14 @@ def _migrate_to_v2(conn: sqlite3.Connection) -> None:
     _add_column_if_missing(conn, "files", "last_tagged_at", "REAL")
 
 
+def _migrate_to_v3(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(conn, "files", "is_present", "INTEGER NOT NULL DEFAULT 1")
+    conn.execute("CREATE INDEX IF NOT EXISTS files_is_present_path_idx ON files(is_present, path)")
+
+
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     2: _migrate_to_v2,
+    3: _migrate_to_v3,
 }
 
 

--- a/src/dup/scanner.py
+++ b/src/dup/scanner.py
@@ -1,0 +1,331 @@
+"""Duplicate scanning pipeline using LSH buckets and DSU clustering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+
+from sig.phash import hamming64
+
+
+_EXTENSION_PRIORITY = {
+    "png": 4,
+    "apng": 4,
+    "webp": 3,
+    "tiff": 2,
+    "tif": 2,
+    "bmp": 1,
+    "gif": 1,
+    "jpeg": 0,
+    "jpg": 0,
+    "jpe": 0,
+    "jfif": 0,
+}
+
+
+@dataclass(frozen=True)
+class DuplicateFile:
+    """Metadata required for duplicate detection of a single file."""
+
+    file_id: int
+    path: Path
+    size: int | None
+    width: int | None
+    height: int | None
+    phash: int
+    embedding: np.ndarray | None
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, object]) -> DuplicateFile:
+        """Create an instance from a database row."""
+
+        phash_value = row.get("phash_u64")
+        if phash_value is None:
+            raise ValueError("Row is missing perceptual hash information")
+        raw_path = Path(str(row.get("path")))
+        size = row.get("size")
+        width = row.get("width")
+        height = row.get("height")
+        embedding: np.ndarray | None = None
+        raw_embedding = row.get("embedding_vector")
+        dim_value = row.get("embedding_dim")
+        if raw_embedding is not None and dim_value is not None:
+            dim = int(dim_value)
+            buffer = raw_embedding
+            if isinstance(buffer, memoryview):
+                buffer = buffer.tobytes()
+            array = np.frombuffer(buffer, dtype=np.float32)
+            if dim > 0:
+                array = array[:dim]
+            embedding = array.astype(np.float32, copy=True) if array.size else None
+        return cls(
+            file_id=int(row.get("file_id")),
+            path=raw_path,
+            size=int(size) if isinstance(size, (int, float)) else None,
+            width=int(width) if isinstance(width, (int, float)) else None,
+            height=int(height) if isinstance(height, (int, float)) else None,
+            phash=int(phash_value),
+            embedding=embedding,
+        )
+
+    @property
+    def resolution(self) -> int:
+        width = self.width or 0
+        height = self.height or 0
+        return width * height
+
+    @property
+    def extension_priority(self) -> int:
+        suffix = self.path.suffix.lower().lstrip(".")
+        return _EXTENSION_PRIORITY.get(suffix, 0)
+
+
+@dataclass(frozen=True)
+class DuplicateClusterEntry:
+    """Single file inside a duplicate cluster."""
+
+    file: DuplicateFile
+    best_hamming: int | None
+    best_cosine: float | None
+
+
+@dataclass(frozen=True)
+class DuplicateCluster:
+    """Duplicate cluster along with the keeper identifier."""
+
+    files: list[DuplicateClusterEntry]
+    keeper_id: int
+
+
+@dataclass(frozen=True)
+class DuplicateScanConfig:
+    """Configuration values controlling duplicate detection thresholds."""
+
+    hamming_threshold: int = 8
+    size_ratio: float | None = None
+    cosine_threshold: float | None = None
+    band_bits: int = 16
+    band_count: int = 4
+
+    def __post_init__(self) -> None:
+        if self.band_bits <= 0:
+            raise ValueError("band_bits must be positive")
+        if self.band_count <= 0:
+            raise ValueError("band_count must be positive")
+        if self.hamming_threshold < 0 or self.hamming_threshold > 64:
+            raise ValueError("hamming_threshold must be in [0, 64]")
+
+
+@dataclass
+class DuplicateEdge:
+    file_id_a: int
+    file_id_b: int
+    hamming: int | None
+    cosine: float | None
+
+
+class DisjointSet:
+    """Disjoint-set union data structure for clustering."""
+
+    def __init__(self) -> None:
+        self._parent: dict[int, int] = {}
+        self._rank: dict[int, int] = {}
+
+    def find(self, item: int) -> int:
+        parent = self._parent.setdefault(item, item)
+        if parent != item:
+            self._parent[item] = self.find(parent)
+        return self._parent[item]
+
+    def union(self, a: int, b: int) -> None:
+        root_a = self.find(a)
+        root_b = self.find(b)
+        if root_a == root_b:
+            return
+        rank_a = self._rank.get(root_a, 0)
+        rank_b = self._rank.get(root_b, 0)
+        if rank_a < rank_b:
+            root_a, root_b = root_b, root_a
+        self._parent[root_b] = root_a
+        if rank_a == rank_b:
+            self._rank[root_a] = rank_a + 1
+
+
+class DuplicateScanner:
+    """Generate duplicate clusters using LSH banding and DSU clustering."""
+
+    def __init__(self, config: DuplicateScanConfig) -> None:
+        self._config = config
+        self._band_mask = (1 << config.band_bits) - 1
+
+    def build_clusters(self, files: Iterable[DuplicateFile]) -> list[DuplicateCluster]:
+        """Return clusters of duplicate files."""
+
+        candidates = [file for file in files if file.phash is not None]
+        if not candidates:
+            return []
+
+        buckets: dict[tuple[int, int], list[int]] = {}
+        for index, file in enumerate(candidates):
+            for band_index in range(self._config.band_count):
+                shift = band_index * self._config.band_bits
+                bucket_key = (band_index, (file.phash >> shift) & self._band_mask)
+                buckets.setdefault(bucket_key, []).append(index)
+
+        edges: dict[tuple[int, int], DuplicateEdge] = {}
+        for indices in buckets.values():
+            if len(indices) < 2:
+                continue
+            for i in range(len(indices) - 1):
+                idx_a = indices[i]
+                file_a = candidates[idx_a]
+                for j in range(i + 1, len(indices)):
+                    idx_b = indices[j]
+                    if idx_a == idx_b:
+                        continue
+                    key = tuple(sorted((file_a.file_id, candidates[idx_b].file_id)))
+                    if key in edges:
+                        continue
+                    file_b = candidates[idx_b]
+                    if not self._passes_size_ratio(file_a, file_b):
+                        continue
+                    hamming = hamming64(file_a.phash, file_b.phash)
+                    if hamming > self._config.hamming_threshold:
+                        continue
+                    cosine = self._compute_cosine_distance(file_a.embedding, file_b.embedding)
+                    if (
+                        self._config.cosine_threshold is not None
+                        and cosine is not None
+                        and cosine > self._config.cosine_threshold
+                    ):
+                        continue
+                    edges[key] = DuplicateEdge(
+                        file_id_a=file_a.file_id,
+                        file_id_b=file_b.file_id,
+                        hamming=hamming,
+                        cosine=cosine,
+                    )
+
+        if not edges:
+            return []
+
+        dsu = DisjointSet()
+        files_by_id = {file.file_id: file for file in candidates}
+        best_hamming: dict[int, int] = {}
+        best_cosine: dict[int, float] = {}
+        for edge in edges.values():
+            dsu.union(edge.file_id_a, edge.file_id_b)
+            for file_id, distance in ((edge.file_id_a, edge.hamming), (edge.file_id_b, edge.hamming)):
+                if distance is not None:
+                    current = best_hamming.get(file_id)
+                    if current is None or distance < current:
+                        best_hamming[file_id] = distance
+            for file_id, distance in ((edge.file_id_a, edge.cosine), (edge.file_id_b, edge.cosine)):
+                if distance is not None:
+                    current = best_cosine.get(file_id)
+                    if current is None or distance < current:
+                        best_cosine[file_id] = distance
+
+        groups: dict[int, list[int]] = {}
+        for file_id in {fid for edge in edges.values() for fid in (edge.file_id_a, edge.file_id_b)}:
+            root = dsu.find(file_id)
+            groups.setdefault(root, []).append(file_id)
+
+        clusters: list[DuplicateCluster] = []
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            entries: list[DuplicateClusterEntry] = []
+            for file_id in sorted(members):
+                file = files_by_id.get(file_id)
+                if file is None:
+                    continue
+                entries.append(
+                    DuplicateClusterEntry(
+                        file=file,
+                        best_hamming=best_hamming.get(file_id),
+                        best_cosine=best_cosine.get(file_id),
+                    )
+                )
+            if len(entries) < 2:
+                continue
+            keeper_id = self._choose_keeper(entries)
+            entries.sort(
+                key=lambda entry: (
+                    0 if entry.file.file_id == keeper_id else 1,
+                    -(entry.file.size or 0),
+                    -entry.file.resolution,
+                    -entry.file.extension_priority,
+                    entry.file.path.name.lower(),
+                    entry.file.file_id,
+                )
+            )
+            clusters.append(DuplicateCluster(files=entries, keeper_id=keeper_id))
+
+        clusters.sort(
+            key=lambda cluster: (
+                -(max(entry.file.size or 0 for entry in cluster.files)),
+                cluster.files[0].file.path.as_posix().lower(),
+            )
+        )
+        return clusters
+
+    def _passes_size_ratio(self, left: DuplicateFile, right: DuplicateFile) -> bool:
+        ratio = self._config.size_ratio
+        if ratio is None or ratio <= 0:
+            return True
+        left_size = left.size or 0
+        right_size = right.size or 0
+        if left_size <= 0 or right_size <= 0:
+            return True
+        smaller = min(left_size, right_size)
+        larger = max(left_size, right_size)
+        if larger == 0:
+            return True
+        return (smaller / larger) >= ratio
+
+    @staticmethod
+    def _compute_cosine_distance(
+        left: np.ndarray | None, right: np.ndarray | None
+    ) -> float | None:
+        if left is None or right is None:
+            return None
+        dim = min(left.shape[0], right.shape[0])
+        if dim == 0:
+            return None
+        vec_a = left[:dim]
+        vec_b = right[:dim]
+        dot = float(np.dot(vec_a, vec_b))
+        distance = 1.0 - dot
+        if distance < 0.0:
+            distance = 0.0
+        if distance > 2.0:
+            distance = 2.0
+        return distance
+
+    @staticmethod
+    def _choose_keeper(entries: Sequence[DuplicateClusterEntry]) -> int:
+        def key(entry: DuplicateClusterEntry) -> tuple:
+            file = entry.file
+            return (
+                -(file.size or 0),
+                -file.resolution,
+                -file.extension_priority,
+                file.path.suffix.lower(),
+                file.path.name.lower(),
+                file.file_id,
+            )
+
+        return min(entries, key=key).file.file_id
+
+
+__all__ = [
+    "DuplicateFile",
+    "DuplicateCluster",
+    "DuplicateClusterEntry",
+    "DuplicateScanConfig",
+    "DuplicateScanner",
+]

--- a/src/ui/dup_tab.py
+++ b/src/ui/dup_tab.py
@@ -2,21 +2,103 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+import csv
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Sequence
 
-from PyQt6.QtCore import Qt
+from send2trash import send2trash
+
+from PyQt6.QtCore import QObject, QPoint, Qt, QRunnable, QThreadPool, pyqtSignal
+from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
+    QFileDialog,
     QDoubleSpinBox,
+    QHeaderView,
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMenu,
+    QMessageBox,
+    QProgressBar,
     QPushButton,
-    QSlider,
-    QTableWidget,
-    QTableWidgetItem,
+    QSpinBox,
+    QTreeWidget,
+    QTreeWidgetItem,
     QVBoxLayout,
     QWidget,
 )
+
+from core.config import load_settings
+from db.connection import get_conn
+from db.repository import iter_files_for_dup, mark_files_absent
+from dup.scanner import (
+    DuplicateCluster,
+    DuplicateClusterEntry,
+    DuplicateFile,
+    DuplicateScanConfig,
+    DuplicateScanner,
+)
+from utils.paths import get_db_path
+
+
+@dataclass(frozen=True)
+class DuplicateScanRequest:
+    """Parameters supplied to the duplicate scanning worker."""
+
+    path_like: str | None
+    hamming_threshold: int
+    size_ratio: float | None
+    cosine_threshold: float | None
+
+
+class DuplicateScanSignals(QObject):
+    """Signals emitted by the scanning worker."""
+
+    progress = pyqtSignal(int, int)
+    finished = pyqtSignal(object)
+    error = pyqtSignal(str)
+
+
+class DuplicateScanRunnable(QRunnable):
+    """Background runnable that loads file metadata and clusters duplicates."""
+
+    def __init__(self, db_path: Path, request: DuplicateScanRequest) -> None:
+        super().__init__()
+        self._db_path = db_path
+        self._request = request
+        self.signals = DuplicateScanSignals()
+
+    def run(self) -> None:  # noqa: D401 - QRunnable interface
+        try:
+            settings = load_settings()
+            model_name = settings.model_name
+            conn = get_conn(self._db_path)
+            try:
+                rows = list(iter_files_for_dup(conn, self._request.path_like, model_name=model_name))
+            finally:
+                conn.close()
+            total = len(rows)
+            self.signals.progress.emit(0, total)
+            files: list[DuplicateFile] = []
+            for index, row in enumerate(rows, start=1):
+                try:
+                    files.append(DuplicateFile.from_row(row))
+                except ValueError:
+                    continue
+                self.signals.progress.emit(index, total)
+            config = DuplicateScanConfig(
+                hamming_threshold=self._request.hamming_threshold,
+                size_ratio=self._request.size_ratio,
+                cosine_threshold=self._request.cosine_threshold,
+            )
+            clusters = DuplicateScanner(config).build_clusters(files)
+            self.signals.finished.emit(clusters)
+        except Exception as exc:  # pragma: no cover - surfaced via UI
+            self.signals.error.emit(str(exc))
 
 
 class DupTab(QWidget):
@@ -24,104 +106,437 @@ class DupTab(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self._file_input = QLineEdit(self)
-        self._file_input.setPlaceholderText("Enter file path or ID…")
-        self._search_button = QPushButton("Search", self)
-        self._cluster_button = QPushButton("Cluster All", self)
+        self._db_path = get_db_path()
+        self._pool = QThreadPool(self)
+        self._clusters: list[DuplicateCluster] = []
+        self._active_scan: DuplicateScanRunnable | None = None
+        self._block_item_changed = False
+
+        self._path_input = QLineEdit(self)
+        self._path_input.setPlaceholderText("Path LIKE pattern (e.g. C:% or %/images/% )")
+
+        self._hamming_spin = QSpinBox(self)
+        self._hamming_spin.setRange(0, 64)
+        self._hamming_spin.setValue(8)
+
+        self._ratio_spin = QDoubleSpinBox(self)
+        self._ratio_spin.setRange(0.0, 1.0)
+        self._ratio_spin.setSingleStep(0.05)
+        self._ratio_spin.setDecimals(2)
+        self._ratio_spin.setValue(0.90)
+        self._ratio_spin.setSpecialValueText("disabled")
+
+        self._cosine_spin = QDoubleSpinBox(self)
+        self._cosine_spin.setRange(0.0, 2.0)
+        self._cosine_spin.setSingleStep(0.05)
+        self._cosine_spin.setDecimals(3)
+        self._cosine_spin.setValue(0.20)
+        self._cosine_spin.setSpecialValueText("disabled")
+
+        self._scan_button = QPushButton("Scan", self)
+        self._mark_button = QPushButton("Mark keep-largest", self)
+        self._uncheck_button = QPushButton("Uncheck all", self)
+        self._trash_button = QPushButton("Trash checked", self)
+        self._export_button = QPushButton("Export CSV", self)
+
+        self._progress = QProgressBar(self)
+        self._progress.setFormat("%v / %m")
+        self._progress.setMaximum(1)
+        self._progress.setValue(0)
+
         self._status_label = QLabel(self)
         self._status_label.setWordWrap(True)
 
-        self._hamming_slider = QSlider(Qt.Orientation.Horizontal, self)
-        self._hamming_slider.setRange(0, 64)
-        self._hamming_slider.setValue(8)
-        self._hamming_value = QLabel("8", self)
+        self._tree = QTreeWidget(self)
+        self._tree.setColumnCount(6)
+        self._tree.setHeaderLabels(["File", "Size", "Resolution", "Hamming", "Cosine", "Path"])
+        self._tree.setAlternatingRowColors(True)
+        header = self._tree.header()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.Stretch)
+        self._tree.setRootIsDecorated(True)
+        self._tree.itemChanged.connect(self._on_item_changed)
+        self._tree.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self._tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._tree.customContextMenuRequested.connect(self._on_context_menu_requested)
 
-        self._cosine_spin = QDoubleSpinBox(self)
-        self._cosine_spin.setRange(0.0, 1.0)
-        self._cosine_spin.setSingleStep(0.01)
-        self._cosine_spin.setValue(0.2)
-
-        self._ssim_spin = QDoubleSpinBox(self)
-        self._ssim_spin.setRange(0.0, 1.0)
-        self._ssim_spin.setSingleStep(0.01)
-        self._ssim_spin.setValue(0.9)
-
-        self._candidate_table = QTableWidget(0, 3, self)
-        self._candidate_table.setHorizontalHeaderLabels(["Candidate", "pHash", "Cosine"])
-        self._candidate_table.horizontalHeader().setStretchLastSection(True)
-        self._candidate_table.verticalHeader().setVisible(False)
-        self._candidate_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-
-        self._cluster_table = QTableWidget(0, 2, self)
-        self._cluster_table.setHorizontalHeaderLabels(["Representative", "Members"])
-        self._cluster_table.horizontalHeader().setStretchLastSection(True)
-        self._cluster_table.verticalHeader().setVisible(False)
-        self._cluster_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-
-        threshold_layout = QHBoxLayout()
-        threshold_layout.addWidget(QLabel("Hamming ≤", self))
-        threshold_layout.addWidget(self._hamming_slider)
-        threshold_layout.addWidget(self._hamming_value)
-        threshold_layout.addWidget(QLabel("Cosine ≤", self))
-        threshold_layout.addWidget(self._cosine_spin)
-        threshold_layout.addWidget(QLabel("SSIM ≥", self))
-        threshold_layout.addWidget(self._ssim_spin)
+        controls_layout = QHBoxLayout()
+        controls_layout.addWidget(QLabel("Path LIKE", self))
+        controls_layout.addWidget(self._path_input, 1)
+        controls_layout.addWidget(QLabel("Hamming ≤", self))
+        controls_layout.addWidget(self._hamming_spin)
+        controls_layout.addWidget(QLabel("Size ratio ≥", self))
+        controls_layout.addWidget(self._ratio_spin)
+        controls_layout.addWidget(QLabel("Cosine ≤", self))
+        controls_layout.addWidget(self._cosine_spin)
 
         button_layout = QHBoxLayout()
-        button_layout.addWidget(self._search_button)
-        button_layout.addWidget(self._cluster_button)
+        button_layout.addWidget(self._scan_button)
+        button_layout.addWidget(self._mark_button)
+        button_layout.addWidget(self._uncheck_button)
+        button_layout.addWidget(self._trash_button)
+        button_layout.addWidget(self._export_button)
+        button_layout.addStretch(1)
+
+        status_layout = QHBoxLayout()
+        status_layout.addWidget(self._progress)
+        status_layout.addWidget(self._status_label, 1)
 
         layout = QVBoxLayout(self)
-        layout.addWidget(self._file_input)
-        layout.addLayout(threshold_layout)
+        layout.addLayout(controls_layout)
         layout.addLayout(button_layout)
-        layout.addWidget(self._status_label)
-        layout.addWidget(QLabel("Candidates", self))
-        layout.addWidget(self._candidate_table)
-        layout.addWidget(QLabel("Clusters", self))
-        layout.addWidget(self._cluster_table)
+        layout.addLayout(status_layout)
+        layout.addWidget(self._tree, 1)
 
-        self._hamming_slider.valueChanged.connect(self._on_hamming_changed)
-        self._search_button.clicked.connect(self._on_search_clicked)
-        self._cluster_button.clicked.connect(self._on_cluster_clicked)
+        self._scan_button.clicked.connect(self._on_scan_clicked)
+        self._mark_button.clicked.connect(self._on_mark_keep_largest)
+        self._uncheck_button.clicked.connect(self._on_uncheck_all)
+        self._trash_button.clicked.connect(self._on_trash_checked)
+        self._export_button.clicked.connect(self._on_export_csv)
 
-    def _on_hamming_changed(self, value: int) -> None:
-        self._hamming_value.setText(str(value))
+        self._update_action_states()
 
-    def _on_search_clicked(self) -> None:
-        query = self._file_input.text().strip() or "(none)"
-        message = (
-            f"Searching {query} with hamming≤{self._hamming_slider.value()}, "
-            f"cosine≤{self._cosine_spin.value():.2f}, ssim≥{self._ssim_spin.value():.2f}"
+    def _update_action_states(self) -> None:
+        has_clusters = bool(self._clusters)
+        self._mark_button.setEnabled(has_clusters)
+        self._uncheck_button.setEnabled(has_clusters)
+        self._export_button.setEnabled(has_clusters)
+        self._trash_button.setEnabled(self._count_checked() > 0)
+
+    def _on_scan_clicked(self) -> None:
+        if self._active_scan is not None:
+            return
+        self._clusters.clear()
+        self._tree.clear()
+        self._update_action_states()
+        request = self._build_request()
+        self._progress.setMaximum(1)
+        self._progress.setValue(0)
+        self._status_label.setText("Scanning duplicates…")
+        runnable = DuplicateScanRunnable(self._db_path, request)
+        runnable.signals.progress.connect(self._on_scan_progress)
+        runnable.signals.finished.connect(self._on_scan_finished)
+        runnable.signals.error.connect(self._on_scan_error)
+        self._active_scan = runnable
+        self._scan_button.setEnabled(False)
+        self._pool.start(runnable)
+
+    def _on_scan_progress(self, current: int, total: int) -> None:
+        if total <= 0:
+            self._progress.setMaximum(1)
+            self._progress.setValue(0)
+            return
+        self._progress.setMaximum(total)
+        self._progress.setValue(current)
+
+    def _on_scan_finished(self, payload: object) -> None:
+        self._active_scan = None
+        self._scan_button.setEnabled(True)
+        if not isinstance(payload, list):
+            self._status_label.setText("Scan completed with unexpected payload")
+            return
+        self._clusters = [cluster for cluster in payload if isinstance(cluster, DuplicateCluster)]
+        if not self._clusters:
+            self._status_label.setText("No duplicate groups detected.")
+            self._tree.clear()
+            self._update_action_states()
+            return
+        self._populate_tree()
+        groups = len(self._clusters)
+        files = sum(len(cluster.files) for cluster in self._clusters)
+        self._status_label.setText(f"Scan complete: {groups} group(s), {files} file(s).")
+        self._update_action_states()
+
+    def _on_scan_error(self, message: str) -> None:
+        self._active_scan = None
+        self._scan_button.setEnabled(True)
+        QMessageBox.critical(self, "Duplicate scan failed", message)
+        self._status_label.setText("Duplicate scan failed.")
+        self._update_action_states()
+
+    def _build_request(self) -> DuplicateScanRequest:
+        path_text = self._path_input.text().strip()
+        like = None
+        if path_text:
+            like = path_text if any(ch in path_text for ch in "%_") else f"{path_text}%"
+        ratio = self._ratio_spin.value()
+        cosine = self._cosine_spin.value()
+        return DuplicateScanRequest(
+            path_like=like,
+            hamming_threshold=self._hamming_spin.value(),
+            size_ratio=ratio if ratio > 0 else None,
+            cosine_threshold=cosine if cosine > 0 else None,
         )
-        self._status_label.setText(message)
-        self._candidate_table.setRowCount(0)
 
-    def _on_cluster_clicked(self) -> None:
-        message = f"Clustering with cosine≤{self._cosine_spin.value():.2f}, " f"ssim≥{self._ssim_spin.value():.2f}"
-        self._status_label.setText(message)
-        self._cluster_table.setRowCount(0)
+    def _populate_tree(self) -> None:
+        self._block_item_changed = True
+        try:
+            self._tree.clear()
+            for group_index, cluster in enumerate(self._clusters, start=1):
+                group_text = f"Group #{group_index} ({len(cluster.files)} items)"
+                group_item = QTreeWidgetItem([group_text, "", "", "", "", ""])
+                group_item.setFirstColumnSpanned(True)
+                flags = group_item.flags()
+                flags &= ~Qt.ItemFlag.ItemIsUserCheckable
+                group_item.setFlags(flags)
+                self._tree.addTopLevelItem(group_item)
+                for entry in self._sort_entries_for_display(cluster.files, cluster.keeper_id):
+                    item = QTreeWidgetItem(group_item)
+                    item.setText(0, entry.file.path.name)
+                    item.setText(1, self._format_size(entry.file.size))
+                    item.setText(2, self._format_resolution(entry.file.width, entry.file.height))
+                    item.setText(3, "-" if entry.best_hamming is None else str(entry.best_hamming))
+                    item.setText(
+                        4,
+                        "-" if entry.best_cosine is None else f"{entry.best_cosine:.3f}",
+                    )
+                    item.setText(5, entry.file.path.as_posix())
+                    item.setData(0, Qt.ItemDataRole.UserRole, entry)
+                    state = (
+                        Qt.CheckState.Unchecked
+                        if entry.file.file_id == cluster.keeper_id
+                        else Qt.CheckState.Checked
+                    )
+                    item.setCheckState(0, state)
+                group_item.setExpanded(True)
+        finally:
+            self._block_item_changed = False
+        self._update_action_states()
 
-    def display_candidates(self, rows: Iterable[tuple[int, int | None, float | None]]) -> None:
-        """Populate candidate table with (file_id, phash_distance, cosine_distance)."""
-        self._candidate_table.setRowCount(0)
-        for index, (file_id, phash_distance, cosine_distance) in enumerate(rows):
-            self._candidate_table.insertRow(index)
-            self._candidate_table.setItem(index, 0, QTableWidgetItem(str(file_id)))
-            self._candidate_table.setItem(
-                index, 1, QTableWidgetItem("-" if phash_distance is None else str(phash_distance))
+    def _on_mark_keep_largest(self) -> None:
+        for cluster_index, cluster in enumerate(self._clusters):
+            top_item = self._tree.topLevelItem(cluster_index)
+            if top_item is None:
+                continue
+            for child_index in range(top_item.childCount()):
+                child = top_item.child(child_index)
+                entry = child.data(0, Qt.ItemDataRole.UserRole)
+                if not isinstance(entry, DuplicateClusterEntry):
+                    continue
+                state = (
+                    Qt.CheckState.Unchecked
+                    if entry.file.file_id == cluster.keeper_id
+                    else Qt.CheckState.Checked
+                )
+                child.setCheckState(0, state)
+        self._update_action_states()
+
+    def _on_uncheck_all(self) -> None:
+        for item, entry in self._iter_tree_entries():
+            if entry is None:
+                continue
+            item.setCheckState(0, Qt.CheckState.Unchecked)
+        self._update_action_states()
+
+    def _on_trash_checked(self) -> None:
+        checked_entries = [
+            entry
+            for item, entry in self._iter_tree_entries()
+            if entry and item.checkState(0) == Qt.CheckState.Checked
+        ]
+        if not checked_entries:
+            QMessageBox.information(self, "Trash duplicates", "No files are checked for deletion.")
+            return
+        successes: list[DuplicateClusterEntry] = []
+        failures: list[tuple[DuplicateClusterEntry, str]] = []
+        for entry in checked_entries:
+            try:
+                send2trash(str(entry.file.path))
+                successes.append(entry)
+            except Exception as exc:  # pragma: no cover - send2trash failures are platform dependent
+                failures.append((entry, str(exc)))
+        if successes:
+            try:
+                conn = get_conn(self._db_path)
+                try:
+                    mark_files_absent(conn, [entry.file.file_id for entry in successes])
+                finally:
+                    conn.close()
+            except Exception as exc:  # pragma: no cover - database errors surfaced via UI
+                failures.extend((entry, str(exc)) for entry in successes)
+                successes.clear()
+        removed_ids = {entry.file.file_id for entry in successes}
+        if removed_ids:
+            new_clusters: list[DuplicateCluster] = []
+            for cluster in self._clusters:
+                rebuilt = self._rebuild_cluster(cluster, removed_ids)
+                if rebuilt is not None:
+                    new_clusters.append(rebuilt)
+            self._clusters = new_clusters
+            self._populate_tree()
+        summary = f"Moved {len(successes)} file(s) to trash."
+        if failures:
+            summary += f" Failed: {len(failures)}."
+        self._status_label.setText(summary)
+        if failures:
+            message = "\n".join(f"{entry.file.path}: {reason}" for entry, reason in failures)
+            QMessageBox.warning(self, "Trash duplicates", f"Some files could not be moved:\n{message}")
+        self._update_action_states()
+
+    def _rebuild_cluster(self, cluster: DuplicateCluster, removed_ids: set[int]) -> DuplicateCluster | None:
+        remaining = [entry for entry in cluster.files if entry.file.file_id not in removed_ids]
+        if len(remaining) < 2:
+            return None
+        new_keeper = self._choose_keeper(remaining)
+        sorted_entries = self._sort_entries_for_display(remaining, new_keeper)
+        return DuplicateCluster(files=sorted_entries, keeper_id=new_keeper)
+
+    def _choose_keeper(self, entries: Sequence[DuplicateClusterEntry]) -> int:
+        def key(entry: DuplicateClusterEntry) -> tuple:
+            file = entry.file
+            return (
+                -(file.size or 0),
+                -file.resolution,
+                -file.extension_priority,
+                file.path.suffix.lower(),
+                file.path.name.lower(),
+                file.file_id,
             )
-            cos_text = "-" if cosine_distance is None else f"{cosine_distance:.4f}"
-            self._candidate_table.setItem(index, 2, QTableWidgetItem(cos_text))
 
-    def display_clusters(self, rows: Iterable[tuple[int, list[int]]]) -> None:
-        """Populate cluster table with representative and members."""
-        self._cluster_table.setRowCount(0)
-        for index, (representative, members) in enumerate(rows):
-            self._cluster_table.insertRow(index)
-            self._cluster_table.setItem(index, 0, QTableWidgetItem(str(representative)))
-            member_text = ", ".join(str(member) for member in members)
-            self._cluster_table.setItem(index, 1, QTableWidgetItem(member_text))
+        return min(entries, key=key).file.file_id
+
+    def _sort_entries_for_display(
+        self, entries: Sequence[DuplicateClusterEntry], keeper_id: int
+    ) -> list[DuplicateClusterEntry]:
+        return sorted(
+            entries,
+            key=lambda entry: (
+                0 if entry.file.file_id == keeper_id else 1,
+                -(entry.file.size or 0),
+                -entry.file.resolution,
+                -entry.file.extension_priority,
+                entry.file.path.name.lower(),
+                entry.file.file_id,
+            ),
+        )
+
+    def _on_export_csv(self) -> None:
+        if not self._clusters:
+            QMessageBox.information(self, "Export duplicates", "No data to export.")
+            return
+        file_path, _ = QFileDialog.getSaveFileName(self, "Export duplicate groups", "duplicates.csv", "CSV Files (*.csv)")
+        if not file_path:
+            return
+        try:
+            with open(file_path, "w", encoding="utf-8", newline="") as handle:
+                writer = csv.writer(handle)
+                writer.writerow(
+                    [
+                        "group",
+                        "file_id",
+                        "path",
+                        "size",
+                        "width",
+                        "height",
+                        "keeper",
+                        "hamming",
+                        "cosine",
+                    ]
+                )
+                for group_index, cluster in enumerate(self._clusters, start=1):
+                    for entry in cluster.files:
+                        writer.writerow(
+                            [
+                                group_index,
+                                entry.file.file_id,
+                                entry.file.path.as_posix(),
+                                entry.file.size or 0,
+                                entry.file.width or 0,
+                                entry.file.height or 0,
+                                1 if entry.file.file_id == cluster.keeper_id else 0,
+                                entry.best_hamming if entry.best_hamming is not None else "",
+                                f"{entry.best_cosine:.6f}" if entry.best_cosine is not None else "",
+                            ]
+                        )
+        except OSError as exc:  # pragma: no cover - filesystem errors depend on environment
+            QMessageBox.warning(self, "Export duplicates", str(exc))
+            return
+        self._status_label.setText(f"Exported duplicate groups to {file_path}.")
+
+    def _on_item_changed(self, item: QTreeWidgetItem, column: int) -> None:
+        if self._block_item_changed or item.parent() is None or column != 0:
+            return
+        self._update_action_states()
+
+    def _on_item_double_clicked(self, item: QTreeWidgetItem, column: int) -> None:
+        entry = item.data(0, Qt.ItemDataRole.UserRole)
+        if isinstance(entry, DuplicateClusterEntry):
+            self._reveal_in_file_manager(entry.file.path)
+
+    def _on_context_menu_requested(self, pos: QPoint) -> None:
+        item = self._tree.itemAt(pos)
+        if item is None:
+            return
+        entry = item.data(0, Qt.ItemDataRole.UserRole)
+        if not isinstance(entry, DuplicateClusterEntry):
+            return
+        menu = QMenu(self)
+        open_file_action = QAction("Open file", self)
+        open_file_action.triggered.connect(lambda: self._open_path(entry.file.path))
+        reveal_action = QAction("Open containing folder", self)
+        reveal_action.triggered.connect(lambda: self._reveal_in_file_manager(entry.file.path))
+        menu.addAction(open_file_action)
+        menu.addAction(reveal_action)
+        menu.exec(self._tree.viewport().mapToGlobal(pos))
+
+    def _open_path(self, path: Path) -> None:
+        try:
+            if os.name == "nt":
+                os.startfile(path)  # type: ignore[attr-defined]
+            elif platform.system() == "Darwin":
+                subprocess.Popen(["open", str(path)])
+            else:
+                subprocess.Popen(["xdg-open", str(path)])
+        except Exception as exc:  # pragma: no cover - platform dependent
+            QMessageBox.warning(self, "Open file", str(exc))
+
+    def _reveal_in_file_manager(self, path: Path) -> None:
+        try:
+            if os.name == "nt":
+                subprocess.Popen(["explorer", "/select,", str(path)])
+            elif platform.system() == "Darwin":
+                subprocess.Popen(["open", "-R", str(path)])
+            else:
+                subprocess.Popen(["xdg-open", str(path.parent)])
+        except Exception as exc:  # pragma: no cover - platform dependent
+            QMessageBox.warning(self, "Reveal in folder", str(exc))
+
+    def _iter_tree_entries(self) -> Iterator[tuple[QTreeWidgetItem, DuplicateClusterEntry | None]]:
+        for index in range(self._tree.topLevelItemCount()):
+            top_item = self._tree.topLevelItem(index)
+            for child_index in range(top_item.childCount()):
+                child = top_item.child(child_index)
+                entry = child.data(0, Qt.ItemDataRole.UserRole)
+                yield child, entry if isinstance(entry, DuplicateClusterEntry) else None
+
+    def _count_checked(self) -> int:
+        return sum(
+            1
+            for item, entry in self._iter_tree_entries()
+            if entry and item.checkState(0) == Qt.CheckState.Checked
+        )
+
+    @staticmethod
+    def _format_size(value: int | None) -> str:
+        if value is None or value <= 0:
+            return "-"
+        units = ["B", "KB", "MB", "GB", "TB"]
+        size = float(value)
+        index = 0
+        while size >= 1024 and index < len(units) - 1:
+            size /= 1024
+            index += 1
+        return f"{size:.1f} {units[index]}"
+
+    @staticmethod
+    def _format_resolution(width: int | None, height: int | None) -> str:
+        if not width or not height:
+            return "-"
+        return f"{width}×{height}"
 
 
 __all__ = ["DupTab"]

--- a/tests/dup/test_scanner.py
+++ b/tests/dup/test_scanner.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from dup.scanner import DuplicateFile, DuplicateScanConfig, DuplicateScanner
+
+
+def make_file(
+    file_id: int,
+    *,
+    path: str,
+    size: int,
+    width: int,
+    height: int,
+    phash: int,
+    embedding: np.ndarray | None = None,
+) -> DuplicateFile:
+    return DuplicateFile(
+        file_id=file_id,
+        path=Path(path),
+        size=size,
+        width=width,
+        height=height,
+        phash=phash,
+        embedding=embedding,
+    )
+
+
+def test_scanner_clusters_and_keeper_selection() -> None:
+    base_hash = 0xFFFF_FFFF_0000_0000
+    files = [
+        make_file(
+            1,
+            path="a.jpg",
+            size=1_000,
+            width=640,
+            height=480,
+            phash=base_hash,
+            embedding=np.array([1.0, 0.0], dtype=np.float32),
+        ),
+        make_file(
+            2,
+            path="b.png",
+            size=2_000,
+            width=640,
+            height=480,
+            phash=base_hash ^ 0x1,
+            embedding=np.array([0.9, 0.1], dtype=np.float32),
+        ),
+        make_file(
+            3,
+            path="c.jpg",
+            size=1_500,
+            width=800,
+            height=600,
+            phash=base_hash ^ 0x2,
+            embedding=np.array([0.95, 0.05], dtype=np.float32),
+        ),
+    ]
+    scanner = DuplicateScanner(DuplicateScanConfig(hamming_threshold=4))
+    clusters = scanner.build_clusters(files)
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    assert cluster.keeper_id == 2  # largest file with preferred extension
+    file_ids = {entry.file.file_id for entry in cluster.files}
+    assert file_ids == {1, 2, 3}
+    for entry in cluster.files:
+        if entry.file.file_id == 2:
+            continue
+        assert entry.best_hamming is not None
+
+
+def test_scanner_honours_ratio_and_cosine_thresholds() -> None:
+    base_hash = 0xAAAA_AAAA_AAAA_AAAA
+    good_embedding_a = np.array([1.0, 0.0], dtype=np.float32)
+    good_embedding_b = np.array([0.8, 0.6], dtype=np.float32)
+    bad_embedding = np.array([-1.0, 0.0], dtype=np.float32)
+    files = [
+        make_file(1, path="small.jpg", size=100, width=100, height=100, phash=base_hash),
+        make_file(
+            2,
+            path="large.jpg",
+            size=1_000,
+            width=100,
+            height=100,
+            phash=base_hash,
+            embedding=good_embedding_b,
+        ),
+        make_file(
+            3,
+            path="cosine_a.jpg",
+            size=800,
+            width=200,
+            height=200,
+            phash=base_hash ^ 0x1,
+            embedding=good_embedding_a,
+        ),
+        make_file(
+            4,
+            path="cosine_b.jpg",
+            size=820,
+            width=200,
+            height=200,
+            phash=base_hash ^ 0x2,
+            embedding=good_embedding_b,
+        ),
+        make_file(
+            5,
+            path="cosine_bad.jpg",
+            size=830,
+            width=200,
+            height=200,
+            phash=base_hash ^ 0x3,
+            embedding=bad_embedding,
+        ),
+    ]
+    scanner = DuplicateScanner(
+        DuplicateScanConfig(hamming_threshold=4, size_ratio=0.5, cosine_threshold=0.5)
+    )
+    clusters = scanner.build_clusters(files)
+    assert len(clusters) == 1
+    ids = {entry.file.file_id for entry in clusters[0].files}
+    assert ids == {2, 3, 4}


### PR DESCRIPTION
## Summary
- add an LSH/DSU-based duplicate scanner with optional size and cosine filters for reuse in the UI
- rebuild the duplicate tab to run scans asynchronously, present clusters in a tree, and support keep-largest, trash, and CSV export flows
- extend the repository/schema with `is_present` tracking plus helper APIs and tests, and add the Send2Trash dependency

## Testing
- PYTHONPATH=src pytest tests/dup/test_scanner.py -q
- PYTHONPATH=src pytest tests/db/test_repository.py::test_iter_files_for_dup_and_mark_absent -q
- pytest *(fails: environment lacks many optional modules such as hypothesis, PyQt stubs, and libGL)*

------
https://chatgpt.com/codex/tasks/task_e_68d78c82b6d083238b76992919054d63