### PR TITLE
検索結果テーブルのホバーハイライトをセル単位から行単位に変更

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,6 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.0
     hooks:

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -62,10 +62,6 @@ if ($Fix) {
         Write-Host ""
         Write-Host "==> no changed Python files to fix" -ForegroundColor Cyan
     } else {
-        Invoke-Step "isort" {
-            & $Python -m isort @ChangedPythonFiles
-        }
-
         Invoke-Step "ruff check --fix" {
             & $Python -m ruff check @ChangedPythonFiles --fix
         }
@@ -82,15 +78,6 @@ Invoke-Step "git diff --check" {
 
 Invoke-Step "git diff --cached --check" {
     git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check
-}
-
-if ($ChangedPythonFiles.Count -eq 0) {
-    Write-Host ""
-    Write-Host "==> no changed Python files to check with isort" -ForegroundColor Cyan
-} else {
-    Invoke-Step "isort check" {
-        & $Python -m isort @ChangedPythonFiles --check-only
-    }
 }
 
 Invoke-Step "ruff check" {

--- a/src/ui/result_delegates.py
+++ b/src/ui/result_delegates.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import html
 from collections.abc import Callable, Iterable
 
-from PyQt6.QtCore import QModelIndex, QRect, QRectF, QSize, Qt
-from PyQt6.QtGui import QPalette, QPixmap, QTextDocument, QTextOption
-from PyQt6.QtWidgets import QApplication, QStyle, QStyledItemDelegate, QStyleOptionViewItem, QWidget
+from PyQt6.QtCore import QEvent, QModelIndex, QRect, QRectF, QSize, Qt
+from PyQt6.QtGui import QMouseEvent, QPalette, QPixmap, QTextDocument, QTextOption
+from PyQt6.QtWidgets import QApplication, QStyle, QStyledItemDelegate, QStyleOptionViewItem, QTableView, QWidget
 
 from ui.tag_rendering import (
     _SCORE_COLOR,
@@ -17,6 +17,52 @@ from ui.tag_rendering import (
     pick_highlight_colors,
     render_tag_html,
 )
+
+
+class HoverRowTableView(QTableView):
+    """QTableView that tracks the hovered row for row-level hover highlighting."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._hover_row: int = -1
+        self.viewport().setMouseTracking(True)
+
+    @property
+    def hover_row(self) -> int:
+        return self._hover_row
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        index = self.indexAt(event.pos())
+        new_row = index.row() if index.isValid() else -1
+        if new_row != self._hover_row:
+            self._hover_row = new_row
+            self.viewport().update()
+        super().mouseMoveEvent(event)
+
+    def leaveEvent(self, event: QEvent) -> None:
+        if self._hover_row != -1:
+            self._hover_row = -1
+            self.viewport().update()
+        super().leaveEvent(event)
+
+
+def _apply_row_hover(opt: QStyleOptionViewItem, index: QModelIndex, hover_row: int) -> None:
+    if hover_row >= 0 and index.row() == hover_row:
+        opt.state = opt.state | QStyle.StateFlag.State_MouseOver
+    else:
+        opt.state = opt.state & ~QStyle.StateFlag.State_MouseOver
+
+
+class HoverAwareDelegate(QStyledItemDelegate):
+    """Default delegate that applies row-level hover highlighting."""
+
+    def paint(self, painter: object, option: QStyleOptionViewItem, index: QModelIndex) -> None:
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        if isinstance(opt.widget, HoverRowTableView):
+            _apply_row_hover(opt, index, opt.widget.hover_row)
+        style = opt.widget.style() if opt.widget else QApplication.style()
+        style.drawControl(QStyle.ControlElement.CE_ItemViewItem, opt, painter, opt.widget)
 
 
 def grid_caption_lines(text: str) -> list[str]:
@@ -63,6 +109,8 @@ class WrappingItemDelegate(QStyledItemDelegate):
     def paint(self, painter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
+        if isinstance(opt.widget, HoverRowTableView):
+            _apply_row_hover(opt, index, opt.widget.hover_row)
         text = opt.text
         opt.text = ""
         style = opt.widget.style() if opt.widget else QApplication.style()
@@ -150,6 +198,8 @@ class HighlightDelegate(QStyledItemDelegate):
     def paint(self, painter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
+        if isinstance(opt.widget, HoverRowTableView):
+            _apply_row_hover(opt, index, opt.widget.hover_row)
         opt.text = ""
         style = opt.widget.style() if opt.widget else QApplication.style()
         style.drawControl(QStyle.ControlElement.CE_ItemViewItem, opt, painter, opt.widget)
@@ -265,6 +315,8 @@ class GridThumbDelegate(QStyledItemDelegate):
 __all__ = [
     "GridThumbDelegate",
     "HighlightDelegate",
+    "HoverAwareDelegate",
+    "HoverRowTableView",
     "WrappingItemDelegate",
     "grid_caption_lines",
     "should_paint_text_background",

--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -35,9 +35,13 @@ from db.connection import get_conn
 from tagger import labels_util
 from tagger.base import TagCategory
 from ui.file_actions import trash_path
-from ui.result_delegates import GridThumbDelegate, HoverAwareDelegate, HoverRowTableView
-from ui.result_delegates import HighlightDelegate as _HighlightDelegate
-from ui.result_delegates import WrappingItemDelegate as _WrappingItemDelegate
+from ui.result_delegates import (
+    GridThumbDelegate,
+    HighlightDelegate,
+    HoverAwareDelegate,
+    HoverRowTableView,
+    WrappingItemDelegate,
+)
 from ui.search_worker import SearchWorker
 from ui.tag_rendering import _SCORE_COLOR
 from ui.tag_rendering import filter_tags_by_threshold as _filter_tags_by_threshold
@@ -271,9 +275,9 @@ class TagsTab(
         self._positive_terms: list[str] = []
         self._relevance_thresholds: dict[int, float] = {}
         self._use_relevance = False
-        self._filename_delegate = _WrappingItemDelegate(self._table_view)
-        self._folder_delegate = _WrappingItemDelegate(self._table_view)
-        self._tags_delegate = _HighlightDelegate(lambda: self._highlight_terms, self._table_view)
+        self._filename_delegate = WrappingItemDelegate(self._table_view)
+        self._folder_delegate = WrappingItemDelegate(self._table_view)
+        self._tags_delegate = HighlightDelegate(lambda: self._highlight_terms, self._table_view)
         tags_col = self._table_model.columnCount() - 1
         if tags_col >= 0:
             if self._table_model.columnCount() > 2:

--- a/src/ui/tags_tab.py
+++ b/src/ui/tags_tab.py
@@ -24,7 +24,6 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QStackedWidget,
-    QTableView,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -36,7 +35,7 @@ from db.connection import get_conn
 from tagger import labels_util
 from tagger.base import TagCategory
 from ui.file_actions import trash_path
-from ui.result_delegates import GridThumbDelegate
+from ui.result_delegates import GridThumbDelegate, HoverAwareDelegate, HoverRowTableView
 from ui.result_delegates import HighlightDelegate as _HighlightDelegate
 from ui.result_delegates import WrappingItemDelegate as _WrappingItemDelegate
 from ui.search_worker import SearchWorker
@@ -222,7 +221,7 @@ class TagsTab(
         ]
         self._table_model = QStandardItemModel(0, len(headers), self)
         self._table_model.setHorizontalHeaderLabels(headers)
-        self._table_view = QTableView(self)
+        self._table_view = HoverRowTableView(self)
         self._table_view.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self._table_view.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
         self._table_view.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
@@ -281,6 +280,7 @@ class TagsTab(
                 self._table_view.setItemDelegateForColumn(1, self._filename_delegate)
                 self._table_view.setItemDelegateForColumn(2, self._folder_delegate)
             self._table_view.setItemDelegateForColumn(tags_col, self._tags_delegate)
+        self._table_view.setItemDelegate(HoverAwareDelegate(self._table_view))
         self._grid_delegate = GridThumbDelegate(self._THUMB_SIZE, self._grid_view)
         self._grid_view.setItemDelegate(self._grid_delegate)
 

--- a/tests/ui/test_highlight_delegate.py
+++ b/tests/ui/test_highlight_delegate.py
@@ -7,7 +7,7 @@ from html import escape
 
 import pytest
 
-from ui.tags_tab import _HighlightDelegate
+from ui.result_delegates import HighlightDelegate
 
 BACKGROUND = "#ffee77"
 FOREGROUND = "#000000"
@@ -37,7 +37,7 @@ def _has_highlight_for_term(html: str, term: str) -> bool:
 
 @pytest.mark.not_gui
 def test_highlight_exact_match_only_with_tags() -> None:
-    html = _HighlightDelegate._to_html_with_highlight(
+    html = HighlightDelegate._to_html_with_highlight(
         text="ignored",
         terms=["nurse"],
         tags=[("nurse", 0.91), ("nurse_cap", 0.80)],
@@ -55,7 +55,7 @@ def test_highlight_exact_match_only_with_tags() -> None:
 
 @pytest.mark.not_gui
 def test_highlight_is_case_insensitive() -> None:
-    html = _HighlightDelegate._to_html_with_highlight(
+    html = HighlightDelegate._to_html_with_highlight(
         text="ignored",
         terms=["NuRSe"],  # 大文字小文字は無視
         tags=[("nurse", 0.75), ("doctor", 0.50)],
@@ -70,7 +70,7 @@ def test_highlight_is_case_insensitive() -> None:
 
 @pytest.mark.not_gui
 def test_highlight_escapes_html_in_names() -> None:
-    html = _HighlightDelegate._to_html_with_highlight(
+    html = HighlightDelegate._to_html_with_highlight(
         text="ignored",
         terms=["<nurse & co>"],
         tags=[("<nurse & co>", 0.50), ("doctor", 0.50)],
@@ -86,7 +86,7 @@ def test_highlight_escapes_html_in_names() -> None:
 
 @pytest.mark.not_gui
 def test_highlight_multiple_terms() -> None:
-    html = _HighlightDelegate._to_html_with_highlight(
+    html = HighlightDelegate._to_html_with_highlight(
         text="ignored",
         terms=["nurse", "doctor"],
         tags=[("patient", 0.33), ("doctor", 0.80), ("nurse", 0.70)],
@@ -106,7 +106,7 @@ def test_highlight_multiple_terms() -> None:
 
 @pytest.mark.not_gui
 def test_highlight_no_match_results_in_plain_list() -> None:
-    html = _HighlightDelegate._to_html_with_highlight(
+    html = HighlightDelegate._to_html_with_highlight(
         text="ignored",
         terms=["surgeon"],
         tags=[("nurse", 0.40), ("doctor", 0.60)],


### PR DESCRIPTION
isort と ruff(I rules) の競合を解消: isort フックを削除して ruff に統一